### PR TITLE
Allow entry of URIs that lack a scheme

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,8 @@
   command line. ([#48](https://github.com/davep/rogallo/pull/48))
 - Added support for working with gemtext files in the local filesystem.
   ([#49](https://github.com/davep/rogallo/pull/49))
+- Added support for typing scheme-less Gemini URIs into the application's
+  command line. ([#51](https://github.com/davep/rogallo/pull/51))
 
 ## v0.2.0
 

--- a/src/rogallo/preflight.py
+++ b/src/rogallo/preflight.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 ##############################################################################
 # Wasat imports.
 from wasat import GeminiURI, URIError
+from wasat.uri import GEMINI_PREFIX
 
 ##############################################################################
 # Local imports.
@@ -50,6 +51,21 @@ def is_likely_capsule(uri: str) -> bool:
     except URIError:
         # If it's not, check if it's likely a relative URI.
         return is_likely_page_relative(uri)
+
+
+##############################################################################
+def is_likely_schemeless_capsule(uri: str) -> bool:
+    """Determine if a URI is likely a schemeless capsule.
+
+    Args:
+        uri: The URI to check.
+
+    Returns:
+        `True` if the URI is likely a schemeless capsule, `False` otherwise.
+    """
+    if urlparse(uri).scheme:
+        return False
+    return is_likely_capsule(f"{GEMINI_PREFIX}{uri}")
 
 
 ##############################################################################

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -23,6 +23,7 @@ from textual_enhanced.screen import EnhancedScreen
 ##############################################################################
 # Wasat imports.
 from wasat import Client, ConnectionError, GeminiURI, Response, SecurityError, URIError
+from wasat.uri import GEMINI_PREFIX
 
 ##############################################################################
 # Local imports.
@@ -51,7 +52,11 @@ from ..data import (
     update_configuration,
 )
 from ..messages import OpenLocation, OpenText, OpenURI
-from ..preflight import is_likely_local_text_file, path_from_uri
+from ..preflight import (
+    is_likely_local_text_file,
+    is_likely_schemeless_capsule,
+    path_from_uri,
+)
 from ..providers import MainCommands
 from ..widgets import CommandLine, HistoryViewer, Viewer
 
@@ -363,6 +368,13 @@ class Main(EnhancedScreen[None]):
         # Perhaps it's a local text file?
         if is_likely_local_text_file(message.uri):
             self.post_message(OpenLocation(path_from_uri(message.uri)))
+            return
+
+        # It's not an obvious Gemini URI, and it's not a file in the local
+        # filesystem. Before we pass it off to the system browser, let's see
+        # it could look like a Gemini URI if we add the scheme.
+        if is_likely_schemeless_capsule(message.uri):
+            self.post_message(OpenLocation(GeminiURI(f"{GEMINI_PREFIX}{message.uri}")))
             return
 
         # Otherwise, try to open it in the system browser.

--- a/src/rogallo/widgets/command_line/general.py
+++ b/src/rogallo/widgets/command_line/general.py
@@ -47,7 +47,7 @@ class GeneralCommand(InputCommand):
 class HelpCommand(GeneralCommand):
     """Show the help screen"""
 
-    COMMAND = "`help`"
+    COMMAND = "`!help`"
     ALIASES = "`?`"
     MESSAGE = Help
 
@@ -56,8 +56,8 @@ class HelpCommand(GeneralCommand):
 class QuitCommand(GeneralCommand):
     """Quit the application"""
 
-    COMMAND = "`quit`"
-    ALIASES = "`q`"
+    COMMAND = "`!quit`"
+    ALIASES = "`!q`"
     MESSAGE = Quit
 
 

--- a/src/rogallo/widgets/command_line/open_gemini_uri.py
+++ b/src/rogallo/widgets/command_line/open_gemini_uri.py
@@ -7,10 +7,12 @@ from textual.widget import Widget
 ##############################################################################
 # Wasat imports.
 from wasat import GeminiURI, URIError
+from wasat.uri import GEMINI_PREFIX
 
 ##############################################################################
 # Local imports.
 from ...messages import OpenLocation
+from ...preflight import is_likely_capsule, is_likely_schemeless_capsule
 from .base_command import InputCommand
 
 
@@ -34,7 +36,10 @@ class OpenGeminiURICommand(InputCommand):
         try:
             uri = GeminiURI(text)
         except URIError:
-            return False
+            if is_likely_schemeless_capsule(text):
+                uri = GeminiURI(f"{GEMINI_PREFIX}{text}")
+            else:
+                return False
         for_widget.post_message(OpenLocation(uri))
         return True
 

--- a/src/rogallo/widgets/command_line/open_gemini_uri.py
+++ b/src/rogallo/widgets/command_line/open_gemini_uri.py
@@ -12,7 +12,7 @@ from wasat.uri import GEMINI_PREFIX
 ##############################################################################
 # Local imports.
 from ...messages import OpenLocation
-from ...preflight import is_likely_capsule, is_likely_schemeless_capsule
+from ...preflight import is_likely_schemeless_capsule
 from .base_command import InputCommand
 
 

--- a/src/rogallo/widgets/command_line/widget.py
+++ b/src/rogallo/widgets/command_line/widget.py
@@ -39,11 +39,11 @@ from .open_other_uri import OpenOtherURICommand
 
 ##############################################################################
 COMMANDS: Final[tuple[type[InputCommand], ...]] = (
-    OpenGeminiURICommand,
-    OpenOtherURICommand,
-    OpenFileCommand,
     HelpCommand,
     QuitCommand,
+    OpenFileCommand,
+    OpenGeminiURICommand,
+    OpenOtherURICommand,
 )
 """The commands used for the input."""
 


### PR DESCRIPTION
In doing so, make things a little easier when it comes to guessing by moving all commands (well, all two of them for now) into being prefixed with `!`.

Closes #38.