### PR TITLE
Don't attempt to render plain text

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - Added the MIME type of the document to the viewer's status bar.
   ([#70](https://github.com/davep/rogallo/pull/70))
+- Handle showing plain text content without attempting to render it as
+  Gemtext. ([#71](https://github.com/davep/rogallo/pull/71))
 
 ## v0.4.0
 

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -247,8 +247,10 @@ class Main(EnhancedScreen[None]):
             return len(self._location_history) > 0 or None
         if action in (Reload.action_name(), CopyLocationToClipboard.action_name()):
             return bool(self._viewer.document.location)
-        if action in (CopyDocumentToClipboard.action_name(), ToggleView.action_name()):
+        if action == CopyDocumentToClipboard.action_name():
             return bool(self._viewer.document)
+        if action == ToggleView.action_name():
+            return self._viewer.document and self._viewer.is_viewing_gemtext
         return True
 
     async def _handle_input_request(self, location: GeminiURI, sensitive: bool) -> None:
@@ -554,7 +556,8 @@ class Main(EnhancedScreen[None]):
 
     def action_toggle_view_command(self) -> None:
         """Toggle the view between rendered and source."""
-        self._viewer.view_source = not self._viewer.view_source
+        if self._viewer.is_viewing_gemtext:
+            self._viewer.view_source = not self._viewer.view_source
 
 
 ### main.py ends here

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -250,7 +250,7 @@ class Main(EnhancedScreen[None]):
         if action == CopyDocumentToClipboard.action_name():
             return bool(self._viewer.document)
         if action == ToggleView.action_name():
-            return self._viewer.document and self._viewer.is_viewing_gemtext
+            return bool(self._viewer.document) and self._viewer.is_viewing_gemtext
         return True
 
     async def _handle_input_request(self, location: GeminiURI, sensitive: bool) -> None:

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -20,7 +20,7 @@ from textual.widgets import Static
 
 ##############################################################################
 # Local imports.
-from ...types import GeminiLocation
+from ...types import GEMINI_MIME_TYPE, GeminiLocation
 from .document_view import DocumentView
 from .gemtext_blocks import GemtextLink, GemtextWidget, get_block_widget
 from .status import ViewerStatus
@@ -69,6 +69,14 @@ class Viewer(Vertical, can_focus=False):
     _status = query_one(ViewerStatus)
     """The status bar widget."""
 
+    @property
+    def is_viewing_gemtext(self) -> bool:
+        """`True` if the viewer is showing a Gemtext document, `False` otherwise.
+
+        Note that this is regardless of the 'view source' status.
+        """
+        return self.document.mime_type == GEMINI_MIME_TYPE
+
     def compose(self) -> ComposeResult:
         """Compose the viewer widget."""
         yield ViewerTitle()
@@ -81,7 +89,7 @@ class Viewer(Vertical, can_focus=False):
         self._status.mime_type = self.document.mime_type or ""
         await self._view.remove_children()
         blocks: list[Static] | list[GemtextWidget]
-        if self.view_source:
+        if (self.document.mime_type != GEMINI_MIME_TYPE) or self.view_source:
             blocks = [Static(self.document.content, markup=False)]
         else:
             for widget in (


### PR DESCRIPTION
Just show it as a simple static widget, rather than treating it as Gemtext first.

In support of #50 (but doesn't close it yet).