### PR TITLE
Add cache support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,6 +43,8 @@
 - Added shortened versions of history, location history and bookmarks as
   application command line completion suggestions.
   ([#103](https://github.com/davep/rogallo/pull/103))
+- Added a content cache for content loaded from remote capsules.
+  ([#104](https://github.com/davep/rogallo/pull/104))
 
 ## v0.4.0
 

--- a/src/rogallo/__main__.py
+++ b/src/rogallo/__main__.py
@@ -9,7 +9,7 @@ from operator import attrgetter
 ##############################################################################
 # Local imports.
 from . import __doc__, __version__
-from .data.locations import config_dir, data_dir
+from .data.locations import cache_dir, config_dir, data_dir
 from .rogallo import Rogallo
 
 
@@ -119,6 +119,7 @@ def main() -> None:
     """Main entry point for the rogallo application."""
     match (args := get_args()).command:
         case "d" | "dirs" | "directories":
+            print(cache_dir())
             print(config_dir())
             print(data_dir())
         case "license" | "licence":

--- a/src/rogallo/cache.py
+++ b/src/rogallo/cache.py
@@ -16,6 +16,7 @@ from wasat import GeminiURI
 
 ##############################################################################
 # Local imports.
+from .data import load_configuration
 from .data.locations import cache_dir
 from .document import Document
 
@@ -49,12 +50,26 @@ class ContentCache(CacheManager):
         Returns:
             The cached document, or `None` if it is not cached.
         """
-        # TODO: Expiration.
         meta_data_file, content_file = self._cache_files(uri)
+
+        # Load the metadata.
         try:
             meta_data = loads(meta_data_file.read_text(encoding="utf-8"))
         except (OSError, JSONDecodeError):
             return None
+
+        # In the unlikely event we can't work out when the document was
+        # cached, treat it as not cached.
+        if (cached_at := meta_data.get("cached_at")) is None:
+            return None
+
+        # See if the cached document has expired.
+        if (
+            datetime.now() - datetime.fromisoformat(cached_at)
+        ).total_seconds() > load_configuration().cache_ttl:
+            return None
+
+        # Load the content and return the document.
         try:
             return Document(
                 location=uri,

--- a/src/rogallo/cache.py
+++ b/src/rogallo/cache.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 from json import JSONDecodeError, dumps, loads
 from pathlib import Path
+from shutil import rmtree
 
 ##############################################################################
 # BagOfStuff imports.
@@ -110,6 +111,10 @@ class ContentCache(CacheManager):
         except OSError:
             pass
         return document
+
+    def clear(self) -> None:
+        """Clear the cache."""
+        rmtree(self.base_path, ignore_errors=True)
 
 
 ### cache.py ends here

--- a/src/rogallo/cache.py
+++ b/src/rogallo/cache.py
@@ -29,6 +29,10 @@ class ContentCache(CacheManager):
     def __init__(self) -> None:
         """Initialise the content cache."""
         super().__init__(cache_dir())
+        self._disabled = not load_configuration().with_cache
+        """Whether the cache is disabled."""
+        self._ttl = load_configuration().cache_ttl
+        """The time-to-live for cached content, in seconds."""
 
     def _cache_files(self, uri: GeminiURI) -> tuple[Path, Path]:
         """Get the paths to the cache files.
@@ -51,6 +55,10 @@ class ContentCache(CacheManager):
         Returns:
             The cached document, or `None` if it is not cached.
         """
+
+        if self._disabled:
+            return None
+
         meta_data_file, content_file = self._cache_files(uri)
 
         # Load the metadata.
@@ -67,7 +75,7 @@ class ContentCache(CacheManager):
         # See if the cached document has expired.
         if (
             datetime.now() - datetime.fromisoformat(cached_at)
-        ).total_seconds() > load_configuration().cache_ttl:
+        ).total_seconds() > self._ttl:
             return None
 
         # Load the content and return the document.
@@ -91,9 +99,12 @@ class ContentCache(CacheManager):
         Returns:
             The document that was cached.
         """
-        if not isinstance(document.location, GeminiURI):
+
+        if self._disabled or not isinstance(document.location, GeminiURI):
             return document
+
         meta_data_file, content_file = self._cache_files(document.location)
+
         try:
             content_file.write_text(document.content, encoding="utf-8")
             meta_data_file.write_text(

--- a/src/rogallo/cache.py
+++ b/src/rogallo/cache.py
@@ -1,0 +1,100 @@
+"""Provides support for a local cache for remote content."""
+
+##############################################################################
+# Python imports.
+from datetime import datetime
+from json import JSONDecodeError, dumps, loads
+from pathlib import Path
+
+##############################################################################
+# BagOfStuff imports.
+from bagofstuff.cache import CacheManager
+
+##############################################################################
+# Wasat imports.
+from wasat import GeminiURI
+
+##############################################################################
+# Local imports.
+from .data.locations import cache_dir
+from .document import Document
+
+
+##############################################################################
+class ContentCache(CacheManager):
+    """A cache manager for remote content."""
+
+    def __init__(self) -> None:
+        """Initialise the content cache."""
+        super().__init__(cache_dir())
+
+    def _cache_files(self, uri: GeminiURI) -> tuple[Path, Path]:
+        """Get the paths to the cache files.
+
+        Args:
+            uri: The URI to get the cache files for.
+
+        Returns:
+            A tuple containing the paths to the cache files.
+        """
+        cache_path = self.get(uri=uri)
+        return cache_path.with_suffix(".meta"), cache_path.with_suffix(".content")
+
+    def get_document(self, uri: GeminiURI) -> Document | None:
+        """Get a cached copy of a document for a given URI.
+
+        Args:
+            uri: The URI to get the cached copy for.
+
+        Returns:
+            The cached document, or `None` if it is not cached.
+        """
+        # TODO: Expiration.
+        meta_data_file, content_file = self._cache_files(uri)
+        try:
+            meta_data = loads(meta_data_file.read_text(encoding="utf-8"))
+        except (OSError, JSONDecodeError):
+            return None
+        try:
+            return Document(
+                location=uri,
+                original_location=GeminiURI(meta_data.get("original_location", uri)),
+                content=content_file.read_text(encoding="utf-8"),
+                mime_type=meta_data.get("mime_type"),
+                from_cache=True,
+            )
+        except OSError:
+            return None
+
+    def add_document(self, document: Document) -> Document:
+        """Add a document to the cache.
+
+        Args:
+            document: The document to cache.
+
+        Returns:
+            The document that was cached.
+        """
+        if not isinstance(document.location, GeminiURI):
+            return document
+        meta_data_file, content_file = self._cache_files(document.location)
+        try:
+            content_file.write_text(document.content, encoding="utf-8")
+            meta_data_file.write_text(
+                dumps(
+                    {
+                        "location": str(document.location),
+                        "original_location": str(document.original_location),
+                        "mime_type": document.mime_type,
+                        "cached_at": datetime.now().isoformat(),
+                    },
+                    indent=4,
+                ),
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+        return document
+
+
+### cache.py ends here

--- a/src/rogallo/commands/__init__.py
+++ b/src/rogallo/commands/__init__.py
@@ -6,6 +6,7 @@ from .clipboard import CopyDocumentToClipboard, CopyLocationToClipboard
 from .main import (
     AddLocationToBookmarks,
     ChangeCommandLineLocation,
+    ClearCache,
     GoHome,
     JumpToCommandLine,
     JumpToDocument,
@@ -25,6 +26,7 @@ from .search import SearchBookmarks, SearchHistory
 __all__ = [
     "AddLocationToBookmarks",
     "Backward",
+    "ClearCache",
     "ChangeCommandLineLocation",
     "CopyDocumentToClipboard",
     "CopyLocationToClipboard",

--- a/src/rogallo/commands/main.py
+++ b/src/rogallo/commands/main.py
@@ -93,4 +93,11 @@ class AddLocationToBookmarks(Command):
     BINDING_KEY = "ctrl+b"
 
 
+##############################################################################
+class ClearCache(Command):
+    """Clear the cache for all content"""
+
+    BINDING_KEY = "shift+f5"
+
+
 ### main.py ends here

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -55,6 +55,9 @@ class Configuration:
     home_page: str = "gemini://geminiprotocol.net/"
     """The home page for the application."""
 
+    cache_ttl: int = 24 * 60 * 60
+    """The time-to-live for cached content, in seconds."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -55,6 +55,9 @@ class Configuration:
     home_page: str = "gemini://geminiprotocol.net/"
     """The home page for the application."""
 
+    with_cache: bool = True
+    """Should the application use a cache for remote content?"""
+
     cache_ttl: int = 24 * 60 * 60
     """The time-to-live for cached content, in seconds."""
 

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -58,7 +58,7 @@ class Configuration:
     with_cache: bool = True
     """Should the application use a cache for remote content?"""
 
-    cache_ttl: int = 24 * 60 * 60
+    cache_ttl: int = 3_600
     """The time-to-live for cached content, in seconds."""
 
 

--- a/src/rogallo/data/locations.py
+++ b/src/rogallo/data/locations.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 ##############################################################################
 # XDG imports.
-from xdg_base_dirs import xdg_config_home, xdg_data_home
+from xdg_base_dirs import xdg_cache_home, xdg_config_home, xdg_data_home
 
 
 ##############################################################################
@@ -53,6 +53,16 @@ def config_dir() -> Path:
         of calling this function.
     """
     return _app_dir(xdg_config_home())
+
+
+##############################################################################
+def cache_dir() -> Path:
+    """The path to the cache directory for the application.
+
+    Returns:
+        The path to the cache directory for the application.
+    """
+    return _app_dir(xdg_cache_home())
 
 
 ### locations.py ends here

--- a/src/rogallo/document.py
+++ b/src/rogallo/document.py
@@ -34,6 +34,9 @@ class Document(NamedTuple):
     mime_type: str | None = None
     """The MIME type of the document, if any."""
 
+    from_cache: bool = False
+    """Whether the document was loaded from cache."""
+
     def __bool__(self) -> bool:
         """Return `True` if the document has content, `False` otherwise."""
         return bool(self.content)

--- a/src/rogallo/messages/opening.py
+++ b/src/rogallo/messages/opening.py
@@ -32,6 +32,8 @@ class OpenLocation(Message):
     """The location to open."""
     from_history: bool = False
     """Whether the location is being opened from history."""
+    allow_cached: bool = True
+    """Whether to allow opening the location from cache."""
 
 
 ##############################################################################

--- a/src/rogallo/providers/main.py
+++ b/src/rogallo/providers/main.py
@@ -16,6 +16,7 @@ from ..commands import (
     AddLocationToBookmarks,
     Backward,
     ChangeCommandLineLocation,
+    ClearCache,
     CopyDocumentToClipboard,
     CopyLocationToClipboard,
     Forward,
@@ -48,6 +49,7 @@ class MainCommands(CommandsProvider):
         yield from self.maybe(Backward)
         yield ChangeCommandLineLocation()
         yield ChangeTheme()
+        yield ClearCache()
         yield from self.maybe(CopyDocumentToClipboard)
         yield from self.maybe(CopyLocationToClipboard)
         yield from self.maybe(Forward)

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -3,15 +3,9 @@
 ##############################################################################
 # Python imports.
 from argparse import Namespace
-from datetime import datetime
-from json import JSONDecodeError, dumps, loads
 from mimetypes import guess_type
 from pathlib import Path
 from webbrowser import open as open_in_browser
-
-##############################################################################
-# BagOfStuff imports.
-from bagofstuff.cache import CacheManager
 
 ##############################################################################
 # Pyperclip imports.
@@ -50,6 +44,7 @@ from wasat.uri import GEMINI_PREFIX
 ##############################################################################
 # Local imports.
 from .. import __version__
+from ..cache import ContentCache
 from ..commands import (
     AddLocationToBookmarks,
     Backward,
@@ -89,7 +84,6 @@ from ..data import (
     trust_file,
     update_configuration,
 )
-from ..data.locations import cache_dir
 from ..document import Document
 from ..messages import CopyToClipboard, OpenDocument, OpenLocation, OpenURI
 from ..preflight import (
@@ -232,7 +226,7 @@ class Main(EnhancedScreen[None]):
         super().__init__()
         self._arguments = arguments
         """The command line arguments."""
-        self._cache = CacheManager(cache_dir())
+        self._cache = ContentCache()
         """The disk cache manager."""
 
     def compose(self) -> ComposeResult:
@@ -275,74 +269,6 @@ class Main(EnhancedScreen[None]):
                     self._location_history.current_item.location, from_history=True
                 )
             )
-
-    def _cache_files(self, uri: GeminiURI) -> tuple[Path, Path]:
-        """Get the paths to the cache files.
-
-        Args:
-            uri: The URI to get the cache files for.
-
-        Returns:
-            A tuple containing the paths to the cache files.
-        """
-        cache_path = self._cache.get(uri=uri)
-        return cache_path.with_suffix(".meta"), cache_path.with_suffix(".content")
-
-    def _cached(self, uri: GeminiURI) -> Document | None:
-        """Get a cached copy of a document for a given URI.
-
-        Args:
-            uri: The URI to get the cached copy for.
-
-        Returns:
-            The cached document, or `None` if it is not cached.
-        """
-        # TODO: Expiration.
-        meta_data_file, content_file = self._cache_files(uri)
-        try:
-            meta_data = loads(meta_data_file.read_text(encoding="utf-8"))
-        except (OSError, JSONDecodeError):
-            return None
-        try:
-            return Document(
-                location=uri,
-                original_location=GeminiURI(meta_data.get("original_location", uri)),
-                content=content_file.read_text(encoding="utf-8"),
-                mime_type=meta_data.get("mime_type"),
-                from_cache=True,
-            )
-        except OSError:
-            return None
-
-    def _add_to_cache(self, document: Document) -> Document:
-        """Cache a document.
-
-        Args:
-            document: The document to cache.
-
-        Returns:
-            The document that was cached.
-        """
-        if not isinstance(document.location, GeminiURI):
-            return document
-        meta_data_file, content_file = self._cache_files(document.location)
-        try:
-            content_file.write_text(document.content, encoding="utf-8")
-            meta_data_file.write_text(
-                dumps(
-                    {
-                        "location": str(document.location),
-                        "original_location": str(document.original_location),
-                        "mime_type": document.mime_type,
-                        "cached_at": datetime.now().isoformat(),
-                    },
-                    indent=4,
-                ),
-                encoding="utf-8",
-            )
-        except OSError:
-            pass
-        return document
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         """Check if an action is possible to perform right now.
@@ -460,7 +386,7 @@ class Main(EnhancedScreen[None]):
         if self._is_displayable(response.mime_type):
             self.post_message(
                 OpenDocument(
-                    document=self._add_to_cache(
+                    document=self._cache.add_document(
                         Document(
                             location=uri,
                             original_location=request.location,
@@ -519,7 +445,7 @@ class Main(EnhancedScreen[None]):
 
         # If a cached copy of the document exists and the request allows it,
         # use that instead of making a network request.
-        if request.allow_cached and (cached_document := self._cached(uri)):
+        if request.allow_cached and (cached_document := self._cache.get_document(uri)):
             self.post_message(
                 OpenDocument(
                     document=cached_document,

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -25,7 +25,7 @@ from textual.widgets import Footer, Header, Label
 ##############################################################################
 # Textual enhanced imports.
 from textual_enhanced.commands import ChangeTheme, Command, Help, Quit
-from textual_enhanced.dialogs import ModalInput
+from textual_enhanced.dialogs import Confirm, ModalInput
 from textual_enhanced.screen import EnhancedScreen
 
 ##############################################################################
@@ -49,6 +49,7 @@ from ..commands import (
     AddLocationToBookmarks,
     Backward,
     ChangeCommandLineLocation,
+    ClearCache,
     CopyDocumentToClipboard,
     CopyLocationToClipboard,
     Forward,
@@ -188,6 +189,7 @@ class Main(EnhancedScreen[None]):
         SetHomeToCurrentLocation,
         SearchHistory,
         SearchBookmarks,
+        ClearCache,
     ]
 
     BINDINGS = Command.bindings(*COMMAND_MESSAGES)
@@ -793,6 +795,18 @@ class Main(EnhancedScreen[None]):
         """Search the bookmarks."""
         BookmarkSearchCommands.bookmarks = self._bookmarks
         self.show_palette(BookmarkSearchCommands)
+
+    @work
+    async def action_clear_cache_command(self) -> None:
+        """Clear the cache."""
+        if await self.app.push_screen_wait(
+            Confirm(
+                "Clear cache",
+                "Are you sure you want to clear all cached content?",
+            )
+        ):
+            self._cache.clear()
+            self.notify("All cached content has been cleared.", title="Cache")
 
 
 ### main.py ends here

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -3,9 +3,15 @@
 ##############################################################################
 # Python imports.
 from argparse import Namespace
+from datetime import datetime
+from json import JSONDecodeError, dumps, loads
 from mimetypes import guess_type
 from pathlib import Path
 from webbrowser import open as open_in_browser
+
+##############################################################################
+# BagOfStuff imports.
+from bagofstuff.cache import CacheManager
 
 ##############################################################################
 # Pyperclip imports.
@@ -83,6 +89,7 @@ from ..data import (
     trust_file,
     update_configuration,
 )
+from ..data.locations import cache_dir
 from ..document import Document
 from ..messages import CopyToClipboard, OpenDocument, OpenLocation, OpenURI
 from ..preflight import (
@@ -225,6 +232,8 @@ class Main(EnhancedScreen[None]):
         super().__init__()
         self._arguments = arguments
         """The command line arguments."""
+        self._cache = CacheManager(cache_dir())
+        """The disk cache manager."""
 
     def compose(self) -> ComposeResult:
         """Compose the content of the main screen."""
@@ -266,6 +275,74 @@ class Main(EnhancedScreen[None]):
                     self._location_history.current_item.location, from_history=True
                 )
             )
+
+    def _cache_files(self, uri: GeminiURI) -> tuple[Path, Path]:
+        """Get the paths to the cache files.
+
+        Args:
+            uri: The URI to get the cache files for.
+
+        Returns:
+            A tuple containing the paths to the cache files.
+        """
+        cache_path = self._cache.get(uri=uri)
+        return cache_path.with_suffix(".meta"), cache_path.with_suffix(".content")
+
+    def _cached(self, uri: GeminiURI) -> Document | None:
+        """Get a cached copy of a document for a given URI.
+
+        Args:
+            uri: The URI to get the cached copy for.
+
+        Returns:
+            The cached document, or `None` if it is not cached.
+        """
+        # TODO: Expiration.
+        meta_data_file, content_file = self._cache_files(uri)
+        try:
+            meta_data = loads(meta_data_file.read_text(encoding="utf-8"))
+        except (OSError, JSONDecodeError):
+            return None
+        try:
+            return Document(
+                location=uri,
+                original_location=GeminiURI(meta_data.get("original_location", uri)),
+                content=content_file.read_text(encoding="utf-8"),
+                mime_type=meta_data.get("mime_type"),
+                from_cache=True,
+            )
+        except OSError:
+            return None
+
+    def _add_to_cache(self, document: Document) -> Document:
+        """Cache a document.
+
+        Args:
+            document: The document to cache.
+
+        Returns:
+            The document that was cached.
+        """
+        if not isinstance(document.location, GeminiURI):
+            return document
+        meta_data_file, content_file = self._cache_files(document.location)
+        try:
+            content_file.write_text(document.content, encoding="utf-8")
+            meta_data_file.write_text(
+                dumps(
+                    {
+                        "location": str(document.location),
+                        "original_location": str(document.original_location),
+                        "mime_type": document.mime_type,
+                        "cached_at": datetime.now().isoformat(),
+                    },
+                    indent=4,
+                ),
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+        return document
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         """Check if an action is possible to perform right now.
@@ -383,11 +460,13 @@ class Main(EnhancedScreen[None]):
         if self._is_displayable(response.mime_type):
             self.post_message(
                 OpenDocument(
-                    document=Document(
-                        location=uri,
-                        original_location=request.location,
-                        content=await response.text(),
-                        mime_type=response.mime_type,
+                    document=self._add_to_cache(
+                        Document(
+                            location=uri,
+                            original_location=request.location,
+                            content=await response.text(),
+                            mime_type=response.mime_type,
+                        )
                     ),
                     original_request=request,
                 )
@@ -435,8 +514,21 @@ class Main(EnhancedScreen[None]):
         Args:
             uri: The Gemini URI to load the document from.
         """
-        assert isinstance(request.location, GeminiURI)
         uri = request.location
+        assert isinstance(uri, GeminiURI)
+
+        # If a cached copy of the document exists and the request allows it,
+        # use that instead of making a network request.
+        if request.allow_cached and (cached_document := self._cached(uri)):
+            self.post_message(
+                OpenDocument(
+                    document=cached_document,
+                    original_request=request,
+                )
+            )
+            return
+
+        # Otherwise, make a request to the capsule and handle the response.
         try:
             self._command_line.working = True
             async with await Client(
@@ -683,7 +775,11 @@ class Main(EnhancedScreen[None]):
         """Reload the current document."""
         if self._viewer.document.location:
             self.post_message(
-                OpenLocation(self._viewer.document.location, from_history=True)
+                OpenLocation(
+                    self._viewer.document.location,
+                    from_history=True,
+                    allow_cached=False,
+                )
             )
 
     def action_copy_location_to_clipboard_command(self) -> None:


### PR DESCRIPTION
Closes #12.

- Adds caching of any 20 response
- Adds a content TTL configuration option (set to 1 day for now)
- Adds a command to clear out *all* cached content
- Adds the cache directory location to the output of the `dirs` command line command