### PR TITLE
Add client certificate support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Rogallo ChangeLog
 
+## Unreleased
+
+- Added support for client certificates.
+  ([#106](https://github.com/davep/rogallo/pull/106))
+
+**Released: WiP**
+
 ## v0.5.0
 
 **Released: 2026-07-10**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
+**Released: WiP**
+
 - Added support for client certificates.
   ([#106](https://github.com/davep/rogallo/pull/106))
-
-**Released: WiP**
+- Pages opened from in-page links now bypass the cache.
+  ([#106](https://github.com/davep/rogallo/pull/106))
 
 ## v0.5.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "textual>=8.2.7",
     "textual-enhanced>=1.6.0",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=0.2.0",
+    "wasat>=0.2.1",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "textual>=8.2.7",
     "textual-enhanced>=1.6.0",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=0.1.0",
+    "wasat>=0.2.0",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/src/rogallo/__main__.py
+++ b/src/rogallo/__main__.py
@@ -91,8 +91,8 @@ def get_args() -> Namespace:
 def show_bindable_commands() -> None:
     """Show the commands that can have bindings applied."""
     from rich.console import Console
-    from rich.markup import escape
 
+    from .safe_escape import escape
     from .screens import Main
 
     console = Console(highlight=False)

--- a/src/rogallo/data/__init__.py
+++ b/src/rogallo/data/__init__.py
@@ -3,6 +3,7 @@
 ##############################################################################
 # Local imports.
 from .bookmarks import Bookmark, Bookmarks, load_bookmarks, save_bookmarks
+from .client_certificates import client_certificates_directory
 from .command_history import (
     CommandLineHistory,
     load_command_history,
@@ -32,6 +33,7 @@ from .trust import trust_file
 __all__ = [
     "Bookmark",
     "Bookmarks",
+    "client_certificates_directory",
     "CommandLineHistory",
     "Configuration",
     "load_bookmarks",

--- a/src/rogallo/data/client_certificates.py
+++ b/src/rogallo/data/client_certificates.py
@@ -1,0 +1,22 @@
+"""Functions for getting the path to the client certificates directory."""
+
+##############################################################################
+# Python imports.
+from pathlib import Path
+
+##############################################################################
+# Local imports.
+from .locations import data_dir
+
+
+##############################################################################
+def client_certificates_directory() -> Path:
+    """The path to the directory that holds the client certificates.
+
+    Returns:
+        The path to the directory that holds the client certificates.
+    """
+    return data_dir() / "client_certificates"
+
+
+### client_certificates.py ends here

--- a/src/rogallo/messages/opening.py
+++ b/src/rogallo/messages/opening.py
@@ -21,6 +21,8 @@ class OpenURI(Message):
 
     uri: str
     """The URI to open."""
+    allow_cached: bool = True
+    """Whether to allow opening the URI from cache."""
 
 
 ##############################################################################

--- a/src/rogallo/safe_escape.py
+++ b/src/rogallo/safe_escape.py
@@ -1,0 +1,36 @@
+"""Provides a safer version of Textual's escape"""
+
+##############################################################################
+# Python imports.
+from re import compile
+
+##############################################################################
+# Textual imports.
+from textual.markup import escape as borked_escape
+
+##############################################################################
+_ESCAPE_SUB_METHOD = compile(r"(\\*)(\[[a-zA-Z#/@][^[]*?])").sub
+"""Tweaked version of the original Textual escape function's regexp.
+
+In Textual it just handles lowercase letters and #/@, but in the real world,
+we need to handle uppercase letters too, at least.
+"""
+
+
+##############################################################################
+def escape(text: str) -> str:
+    """Escape text for use in Textual markup.
+
+    Args:
+        text: The text to escape.
+
+    Returns:
+        The escaped text.
+    """
+    # Use the original escape function from Textual, but replace the
+    # problematic regexp with something approaching behaviour suitable for
+    # real world data.
+    return borked_escape(text, _ESCAPE_SUB_METHOD)
+
+
+### safe_escape.py ends here

--- a/src/rogallo/screens/certificate.py
+++ b/src/rogallo/screens/certificate.py
@@ -1,0 +1,184 @@
+"""Provides a dialog for setting the values of a certificate."""
+
+##############################################################################
+# Python imports.
+from typing import Any
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import HorizontalGroup, VerticalGroup
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Collapsible, Input, Label, Rule
+
+##############################################################################
+# Textual enhanced imports.
+from textual_enhanced.tools import add_key
+
+##############################################################################
+# Wasat imports.
+from wasat import GeminiURI
+
+##############################################################################
+type CertificateData = dict[str, Any]
+"""Type of the data returned from the certificate dialog."""
+
+
+##############################################################################
+class Certificate(ModalScreen[CertificateData | None]):
+    """A modal screen to get a certificate from the user."""
+
+    CSS = """
+    Certificate {
+        align: center middle;
+
+        &> VerticalGroup {
+            width: 60%;
+            height: auto;
+            background: $panel;
+            border: panel $border;
+        }
+
+        Collapsible {
+            background: transparent;
+            padding-right: 4;
+            border-top: blank;
+        }
+
+        #buttons {
+            height: auto;
+            margin-top: 1;
+            align-horizontal: right;
+        }
+
+        Button {
+            margin-right: 1;
+        }
+
+        .leave-room {
+            margin-top: 1;
+        }
+
+        Label {
+            margin-left: 1;
+        }
+
+        /* Because https://github.com/Textualize/textual/issues/3945 */
+        Label.leave-room {
+            margin-top: 1;
+            margin-left: 1;
+        }
+    }
+    """
+
+    BINDINGS = [("escape", "cancel"), ("f2", "create")]
+
+    def __init__(self, location: GeminiURI, reason: str) -> None:
+        """Initialise the object.
+
+        Args:
+            location: The location making the request.
+            reason: The reason for the certificate request.
+        """
+        super().__init__()
+        self._location = location
+        """The location making the request."""
+        self._reason = reason.strip()
+        """The reason for the certificate request."""
+
+    def compose(self) -> ComposeResult:
+        """Compose the certificate dialog."""
+        with VerticalGroup() as dialog:
+            dialog.border_title = f"Certificate Request for {self._location}"
+            if self._reason:
+                yield Label(f"Reason: {self._reason}")
+                yield Rule()
+            yield Label("Common Name [dim](leave blank to use the host name)[/]:")
+            yield Input(
+                placeholder="Enter a descriptive name for the certificate",
+                id="common_name",
+            )
+            with Collapsible(title="Advanced options"):
+                yield Checkbox(
+                    "Transient [dim](not saved to disk)[/]",
+                    id="transient",
+                    classes="leave-room",
+                )
+                yield Label(
+                    "Valid for [dim](in days, <=0 is until 9999-12-31)[/]:",
+                    classes="leave-room",
+                )
+                yield Input(
+                    "0",
+                    placeholder="Enter the number of days the certificate is valid for",
+                    id="valid-for",
+                    type="integer",
+                )
+                yield Label("Email address [dim](optional)[/]:", classes="leave-room")
+                yield Input(
+                    placeholder="Enter an email address for the certificate", id="email"
+                )
+                yield Label("User ID [dim](optional)[/]:", classes="leave-room")
+                yield Input(
+                    placeholder="Enter a user ID for the certificate", id="user_id"
+                )
+                yield Label("Domain [dim](optional)[/]:", classes="leave-room")
+                yield Input(
+                    placeholder="Enter a domain for the certificate", id="domain"
+                )
+                yield Label("Organisation [dim](optional)[/]:", classes="leave-room")
+                yield Input(
+                    placeholder="Enter an organization for the certificate",
+                    id="organisation",
+                )
+                yield Label(
+                    "Country [dim](optional, 2-letter code)[/]:", classes="leave-room"
+                )
+                yield Input(
+                    placeholder="Enter a country code for the certificate",
+                    id="country",
+                    max_length=2,
+                )
+            with HorizontalGroup(id="buttons"):
+                yield Button(add_key("Create", "F2"), id="create", variant="success")
+                yield Button(add_key("Cancel", "Esc"), id="cancel", variant="error")
+
+    def _maybe_add(self, data: CertificateData, key: str) -> None:
+        """Maybe add a value to the certificate data.
+
+        Args:
+            data: The data to add to.
+            key: The key to add.
+        """
+        if value := self.query_one(f"#{key}", Input).value.strip():
+            data[key] = value
+
+    @on(Button.Pressed, "#create")
+    def action_create(self) -> None:
+        """Create the certificate."""
+        certificate_data: CertificateData = {
+            "transient": self.query_one("#transient", Checkbox).value
+        }
+        self._maybe_add(certificate_data, "common_name")
+        try:
+            if (
+                valid_days := int(self.query_one("#valid-for", Input).value.strip())
+            ) > 0:
+                certificate_data["valid_days"] = valid_days
+        except ValueError:
+            pass
+        self._maybe_add(certificate_data, "email")
+        self._maybe_add(certificate_data, "user_id")
+        self._maybe_add(certificate_data, "domain")
+        self._maybe_add(certificate_data, "organisation")
+        self._maybe_add(certificate_data, "country")
+        self.dismiss(certificate_data)
+
+    @on(Button.Pressed, "#cancel")
+    def action_cancel(self) -> None:
+        """Cancel the edit of the raindrop data."""
+        self.dismiss(None)
+
+
+### certificate.py ends here

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -365,7 +365,9 @@ class Main(EnhancedScreen[None]):
             UserInput(location, prompt=prompt, sensitive=sensitive)
         ):
             try:
-                self.post_message(OpenLocation(location.with_query(user_input)))
+                self.post_message(
+                    OpenLocation(location.with_query(user_input), allow_cached=False)
+                )
             except URIError as error:
                 self.notify(
                     f"Unable to create query for {location}:\n\n{error}",

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -33,7 +33,6 @@ from textual_enhanced.screen import EnhancedScreen
 from wasat import (
     Client,
     ConnectionError,
-    FileClientCertificateStore,
     GeminiURI,
     Response,
     SecurityError,
@@ -232,6 +231,12 @@ class Main(EnhancedScreen[None]):
         """The command line arguments."""
         self._cache = ContentCache()
         """The disk cache manager."""
+        self._client = Client(
+            verify_mode="tofu",
+            trust_store_path=trust_file(),
+            client_cert_store_path=client_certificates_directory(),
+        )
+        """The Gemini client."""
 
     def compose(self) -> ComposeResult:
         """Compose the content of the main screen."""
@@ -381,9 +386,7 @@ class Main(EnhancedScreen[None]):
         ) is None:
             self.notify("Client certificate request cancelled.", severity="warning")
             return
-        await FileClientCertificateStore(
-            client_certificates_directory()
-        ).create_credentials(
+        await self._client.client_cert_store.create_credentials(
             uri=location,
             transient=False,
             common_name=common_name.strip(),
@@ -412,7 +415,8 @@ class Main(EnhancedScreen[None]):
 
         # Handle a request for a client certificate.
         if response.status.is_client_certificate_required:
-            await self._handle_client_certificate_request(uri)
+            if not await self._client.client_cert_store.get_credentials(uri):
+                await self._handle_client_certificate_request(uri)
             return
 
         # Handle any other non-successful response.
@@ -499,11 +503,7 @@ class Main(EnhancedScreen[None]):
         # Otherwise, make a request to the capsule and handle the response.
         try:
             self._command_line.working = True
-            async with await Client(
-                verify_mode="tofu",
-                trust_store_path=trust_file(),
-                client_cert_store_path=client_certificates_directory(),
-            ).request(uri) as response:
+            async with await self._client.request(uri) as response:
                 await self._handle_response(response, request)
         except ConnectionError as error:
             self.notify(

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -347,7 +347,9 @@ class Main(EnhancedScreen[None]):
             mime_type, _, _ = mime_type.partition(";")
         return mime_type in load_configuration().displayable_content_types
 
-    async def _handle_input_request(self, location: GeminiURI, sensitive: bool) -> None:
+    async def _handle_input_request(
+        self, location: GeminiURI, prompt: str, sensitive: bool
+    ) -> None:
         """Handle a request for input from a Gemini request.
 
         Args:
@@ -355,7 +357,7 @@ class Main(EnhancedScreen[None]):
             sensitive: Whether the input is sensitive.
         """
         if user_input := await self.app.push_screen_wait(
-            UserInput(location, sensitive)
+            UserInput(location, prompt=prompt, sensitive=sensitive)
         ):
             try:
                 self.post_message(OpenLocation(location.with_query(user_input)))
@@ -402,7 +404,9 @@ class Main(EnhancedScreen[None]):
         # Handle a request for user input.
         if response.status.is_input:
             await self._handle_input_request(
-                request.location, response.status is StatusCode.SENSITIVE_INPUT
+                request.location,
+                response.meta.strip(),
+                response.status is StatusCode.SENSITIVE_INPUT,
             )
             return
 

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -379,8 +379,9 @@ class Main(EnhancedScreen[None]):
         ) is None:
             # TODO: Notify the user that access is denied or something?
             return
-        store = FileClientCertificateStore(client_certificates_directory())
-        await store.create_credentials(
+        await FileClientCertificateStore(
+            client_certificates_directory()
+        ).create_credentials(
             uri=location,
             transient=False,
             common_name=common_name.strip(),

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -581,7 +581,9 @@ class Main(EnhancedScreen[None]):
 
         # Does it look like a Gemini URI?
         try:
-            self.post_message(OpenLocation(GeminiURI(message.uri)))
+            self.post_message(
+                OpenLocation(GeminiURI(message.uri), allow_cached=message.allow_cached)
+            )
             return
         except URIError:
             pass
@@ -595,7 +597,12 @@ class Main(EnhancedScreen[None]):
         # filesystem. Before we pass it off to the system browser, let's see
         # it could look like a Gemini URI if we add the scheme.
         if is_likely_schemeless_capsule(message.uri):
-            self.post_message(OpenLocation(GeminiURI(f"{GEMINI_PREFIX}{message.uri}")))
+            self.post_message(
+                OpenLocation(
+                    GeminiURI(f"{GEMINI_PREFIX}{message.uri}"),
+                    allow_cached=message.allow_cached,
+                )
+            )
             return
 
         # Otherwise, try to open it in the system browser.

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -73,6 +73,7 @@ from ..data import (
     LocationHistory,
     LocationVisit,
     NavigationHistory,
+    client_certificates_directory,
     load_bookmarks,
     load_command_history,
     load_configuration,
@@ -460,7 +461,9 @@ class Main(EnhancedScreen[None]):
         try:
             self._command_line.working = True
             async with await Client(
-                verify_mode="tofu", trust_store_path=trust_file()
+                verify_mode="tofu",
+                trust_store_path=trust_file(),
+                client_cert_store_path=client_certificates_directory(),
             ).request(uri) as response:
                 await self._handle_response(response, request)
         except ConnectionError as error:

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -279,6 +279,10 @@ class Main(EnhancedScreen[None]):
                 )
             )
 
+    async def on_unmount(self) -> None:
+        """Called when the screen is unmounted."""
+        await self._client.close()
+
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         """Check if an action is possible to perform right now.
 

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -379,15 +379,22 @@ class Main(EnhancedScreen[None]):
                     title="Input Error",
                 )
 
-    async def _handle_client_certificate_request(self, location: GeminiURI) -> None:
+    async def _handle_client_certificate_request(
+        self, location: GeminiURI, request_reason: str
+    ) -> None:
         """Handle a request for a client certificate from a Gemini request.
 
         Args:
             location: The location making the request.
+            request_reason: The reason for the client certificate request.
         """
         if (
             common_name := await self.app.push_screen_wait(
-                ModalInput("Enter a descriptive name for the client certificate")
+                ModalInput(
+                    "Enter a descriptive name for the client certificate",
+                    title=f"Client certificate request for {location}",
+                    sub_title=request_reason,
+                )
             )
         ) is None:
             self.notify("Client certificate request cancelled.", severity="warning")
@@ -421,7 +428,7 @@ class Main(EnhancedScreen[None]):
 
         # Handle a request for a client certificate.
         if response.status.is_client_certificate_required:
-            await self._handle_client_certificate_request(uri)
+            await self._handle_client_certificate_request(uri, response.meta.strip())
             return
 
         # Handle any other non-successful response.

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -33,6 +33,7 @@ from textual_enhanced.screen import EnhancedScreen
 from wasat import (
     Client,
     ConnectionError,
+    FileClientCertificateStore,
     GeminiURI,
     Response,
     SecurityError,
@@ -365,6 +366,28 @@ class Main(EnhancedScreen[None]):
                     title="Input Error",
                 )
 
+    async def _handle_client_certificate_request(self, location: GeminiURI) -> None:
+        """Handle a request for a client certificate from a Gemini request.
+
+        Args:
+            location: The location making the request.
+        """
+        if (
+            common_name := await self.app.push_screen_wait(
+                ModalInput("Enter a descriptive name for the client certificate")
+            )
+        ) is None:
+            # TODO: Notify the user that access is denied or something?
+            return
+        store = FileClientCertificateStore(client_certificates_directory())
+        await store.create_credentials(
+            uri=location,
+            transient=False,
+            common_name=common_name.strip(),
+            valid_days=None,
+        )
+        self.post_message(OpenLocation(location, allow_cached=False))
+
     async def _handle_response(self, response: Response, request: OpenLocation) -> None:
         """Handle a response from a Gemini request.
 
@@ -374,11 +397,20 @@ class Main(EnhancedScreen[None]):
         """
         assert isinstance(request.location, GeminiURI)
         uri = response.uri or response.requested_uri or request.location
+
+        # Handle a request for user input.
         if response.status.is_input:
             await self._handle_input_request(
                 request.location, response.status is StatusCode.SENSITIVE_INPUT
             )
             return
+
+        # Handle a request for a client certificate.
+        if response.status.is_client_certificate_required:
+            await self._handle_client_certificate_request(uri)
+            return
+
+        # Handle any other non-successful response.
         if not response.status.is_success:
             self.notify(
                 f"Error loading {uri}:\n\n{response.status.value} {response.status.name}\n{response.meta}",
@@ -386,6 +418,8 @@ class Main(EnhancedScreen[None]):
                 title="Request Error",
             )
             return
+
+        # Handle a successful response.
         if self._is_displayable(response.mime_type):
             self.post_message(
                 OpenDocument(

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -421,8 +421,7 @@ class Main(EnhancedScreen[None]):
 
         # Handle a request for a client certificate.
         if response.status.is_client_certificate_required:
-            if not await self._client.client_cert_store.get_credentials(uri):
-                await self._handle_client_certificate_request(uri)
+            await self._handle_client_certificate_request(uri)
             return
 
         # Handle any other non-successful response.

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -377,7 +377,7 @@ class Main(EnhancedScreen[None]):
                 ModalInput("Enter a descriptive name for the client certificate")
             )
         ) is None:
-            # TODO: Notify the user that access is denied or something?
+            self.notify("Client certificate request cancelled.", severity="warning")
             return
         await FileClientCertificateStore(
             client_certificates_directory()

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -407,7 +407,7 @@ class Main(EnhancedScreen[None]):
         # Handle a request for user input.
         if response.status.is_input:
             await self._handle_input_request(
-                request.location,
+                uri,
                 response.meta.strip(),
                 response.status is StatusCode.SENSITIVE_INPUT,
             )

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -96,6 +96,7 @@ from ..preflight import (
 from ..providers import BookmarkSearchCommands, HistorySearchCommands, MainCommands
 from ..types import GeminiLocation
 from ..widgets import BookmarksViewer, CommandLine, HistoryViewer, Viewer
+from .certificate import Certificate
 from .user_input import UserInput
 
 
@@ -389,21 +390,14 @@ class Main(EnhancedScreen[None]):
             request_reason: The reason for the client certificate request.
         """
         if (
-            common_name := await self.app.push_screen_wait(
-                ModalInput(
-                    "Enter a descriptive name for the client certificate",
-                    title=f"Client certificate request for {location}",
-                    sub_title=request_reason,
-                )
+            certificate_data := await self.app.push_screen_wait(
+                Certificate(location, request_reason)
             )
         ) is None:
             self.notify("Client certificate request cancelled.", severity="warning")
             return
         await self._client.client_cert_store.create_credentials(
-            uri=location,
-            transient=False,
-            common_name=common_name.strip(),
-            valid_days=None,
+            uri=location, **certificate_data
         )
         self.post_message(OpenLocation(location, allow_cached=False))
 

--- a/src/rogallo/screens/user_input.py
+++ b/src/rogallo/screens/user_input.py
@@ -3,16 +3,13 @@
 ##############################################################################
 # Textual imports.
 from textual.app import ComposeResult
+from textual.content import Content
 from textual.screen import ModalScreen
 from textual.widgets import TextArea
 
 ##############################################################################
 # Wasat imports.
 from wasat import GeminiURI
-
-##############################################################################
-# Local imports.
-from ..safe_escape import escape
 
 
 ##############################################################################
@@ -65,7 +62,7 @@ class UserInput(ModalScreen[str | None]):
                 highlight_cursor_line=False, placeholder="Enter your input here..."
             )
         )
-        user_input.border_title = escape(
+        user_input.border_title = Content(
             self._prompt
             or (
                 f"{'Sensitive input' if self._sensitive else 'Input'} for {self._location}"

--- a/src/rogallo/screens/user_input.py
+++ b/src/rogallo/screens/user_input.py
@@ -38,16 +38,19 @@ class UserInput(ModalScreen[str | None]):
         ("f2", "submit"),
     ]
 
-    def __init__(self, location: GeminiURI, sensitive: bool) -> None:
+    def __init__(self, location: GeminiURI, prompt: str, sensitive: bool) -> None:
         """Initialise the object.
 
         Args:
             request_from: The request that prompted this input.
+            prompt: The prompt to display to the user.
             sensitive: Whether the input is sensitive.
         """
         super().__init__(classes=("--sensitive" if sensitive else ""))
         self._location = location
         """The location making the request."""
+        self._prompt = prompt.strip()
+        """The prompt to display to the user."""
         self._sensitive = sensitive
         """Whether the input is sensitive."""
 
@@ -58,7 +61,7 @@ class UserInput(ModalScreen[str | None]):
                 highlight_cursor_line=False, placeholder="Enter your input here..."
             )
         )
-        user_input.border_title = (
+        user_input.border_title = self._prompt or (
             f"{'Sensitive input' if self._sensitive else 'Input'} for {self._location}"
             if self._location
             else "Input"

--- a/src/rogallo/screens/user_input.py
+++ b/src/rogallo/screens/user_input.py
@@ -10,6 +10,10 @@ from textual.widgets import TextArea
 # Wasat imports.
 from wasat import GeminiURI
 
+##############################################################################
+# Local imports.
+from ..safe_escape import escape
+
 
 ##############################################################################
 class UserInput(ModalScreen[str | None]):
@@ -61,10 +65,13 @@ class UserInput(ModalScreen[str | None]):
                 highlight_cursor_line=False, placeholder="Enter your input here..."
             )
         )
-        user_input.border_title = self._prompt or (
-            f"{'Sensitive input' if self._sensitive else 'Input'} for {self._location}"
-            if self._location
-            else "Input"
+        user_input.border_title = escape(
+            self._prompt
+            or (
+                f"{'Sensitive input' if self._sensitive else 'Input'} for {self._location}"
+                if self._location
+                else "Input"
+            )
         )
         user_input.border_subtitle = "Press F2 to submit"
 

--- a/src/rogallo/widgets/bookmarks.py
+++ b/src/rogallo/widgets/bookmarks.py
@@ -9,10 +9,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 ##############################################################################
-# Rich imports.
-from rich.markup import escape
-
-##############################################################################
 # Textual imports.
 from textual import on, work
 from textual.message import Message
@@ -29,6 +25,7 @@ from textual_enhanced.widgets import EnhancedOptionList
 # Local imports.
 from ..data.bookmarks import Bookmark, Bookmarks
 from ..messages import OpenLocation
+from ..safe_escape import escape
 from ..types import short_location
 
 

--- a/src/rogallo/widgets/history.py
+++ b/src/rogallo/widgets/history.py
@@ -10,10 +10,6 @@ from dataclasses import dataclass
 from datetime import datetime
 
 ##############################################################################
-# Rich imports.
-from rich.markup import escape
-
-##############################################################################
 # Textual imports.
 from textual import on, work
 from textual.message import Message
@@ -30,6 +26,7 @@ from textual_enhanced.widgets import EnhancedOptionList
 # Local imports.
 from ..data import LocationHistory, LocationVisit
 from ..messages import OpenLocation
+from ..safe_escape import escape
 from ..types import GeminiLocation, short_location
 
 

--- a/src/rogallo/widgets/viewer/gemtext_blocks.py
+++ b/src/rogallo/widgets/viewer/gemtext_blocks.py
@@ -245,7 +245,7 @@ class GemtextLink(Horizontal, can_focus=True):
     @on(Click)
     def _action_open_link(self) -> None:
         """Open the link."""
-        self.post_message(OpenURI(self._normalised_uri))
+        self.post_message(OpenURI(self._normalised_uri, allow_cached=False))
 
 
 ##############################################################################

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ requires-dist = [
     { name = "textual", specifier = ">=8.2.7" },
     { name = "textual-enhanced", specifier = ">=1.6.0" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=0.2.0" },
+    { name = "wasat", specifier = ">=0.2.1" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -1444,14 +1444,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/84/06a08bcaa9c6805e674abb96bf5ed10c492116c44b4b17ed8fe3e73b6166/wasat-0.2.0.tar.gz", hash = "sha256:3e607454ff14ef5960113296492f548c0a736b5a74248defb35b297040d2471f", size = 19106, upload-time = "2026-07-10T10:36:18.499Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0e/4e015952159b30f6a8d4eb5c4e8a5009846d22386457d7832050a3bfa628/wasat-0.2.1.tar.gz", hash = "sha256:68554c2526353f82a272439eb19bad92f3c632a60fdc1c1959bd7ee2926d3f18", size = 19320, upload-time = "2026-07-10T16:10:13.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/fd/e5942278d30ed3feeffbf3e440c899ca1ec8615a0f3b56deb45e8ca1a308/wasat-0.2.0-py3-none-any.whl", hash = "sha256:24dfca7b22adb2f57dd9e7df9e020be52a7c8beea34ecf8966721fe1f3be58a9", size = 23147, upload-time = "2026-07-10T10:36:17.386Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/f00d27882e71d07ccb6f8e6ea4e93bb3153d0ee6618521d839c1a90cf41d/wasat-0.2.1-py3-none-any.whl", hash = "sha256:5d0307fc6e412b5aaebd12dbb7aea423d890de4015485535b2ef2b8ad1a92d93", size = 23348, upload-time = "2026-07-10T16:10:12.118Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ requires-dist = [
     { name = "textual", specifier = ">=8.2.7" },
     { name = "textual-enhanced", specifier = ">=1.6.0" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=0.1.0" },
+    { name = "wasat", specifier = ">=0.2.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -1444,14 +1444,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/fd/5fd1d808bdef1fabdfe105ead9f0c810a1c1b7a24c3ddbb76325db13bf05/wasat-0.1.0.tar.gz", hash = "sha256:1b182d135b85e1d80608b7bf18bb41eae7551ef6651453c3e5626f89334389d1", size = 18988, upload-time = "2026-06-24T07:44:24.051Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/84/06a08bcaa9c6805e674abb96bf5ed10c492116c44b4b17ed8fe3e73b6166/wasat-0.2.0.tar.gz", hash = "sha256:3e607454ff14ef5960113296492f548c0a736b5a74248defb35b297040d2471f", size = 19106, upload-time = "2026-07-10T10:36:18.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/1c/c6e64c88fbaf95d517e25f3d2b32c8df1ed2286fc4a9b7e00e877ed7d496/wasat-0.1.0-py3-none-any.whl", hash = "sha256:90e83d669120e79d2b72679238128b6edc11f4c4429c25db9506382a4bf71e9b", size = 23051, upload-time = "2026-06-24T07:44:22.882Z" },
+    { url = "https://files.pythonhosted.org/packages/db/fd/e5942278d30ed3feeffbf3e440c899ca1ec8615a0f3b56deb45e8ca1a308/wasat-0.2.0-py3-none-any.whl", hash = "sha256:24dfca7b22adb2f57dd9e7df9e020be52a7c8beea34ecf8966721fe1f3be58a9", size = 23147, upload-time = "2026-07-10T10:36:17.386Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #11.
Closes #107.

This PR also makes some changes to how and when the cache is used, as this affects the content of some pages I was testing with when trying out the main purpose of this PR.

TODO:

- [x] Provide user feedback when a certificate isn't created (user escapes out of name input)
- [x] Test default certificate name generation
- [x] Review the interaction with the cache (failed requests should invalidate the cache somehow)
- [x] When a certificate is required, show the user the reason why as given by the server -- it should be in the metadata of the response.
- [x] Create a custom certificate creation dialog for `_handle_client_certificate_request` (the current one is just a `ModalInput` and it would be good to better show the reasons for the request, and perhaps also prompt for some of the optional certificate fields).