### PR TITLE
Experiments with certificate scopes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "textual>=8.2.7",
     "textual-enhanced>=1.6.0",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=0.3.0",
+    "wasat>=0.3.1",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ requires-dist = [
     { name = "textual", specifier = ">=8.2.7" },
     { name = "textual-enhanced", specifier = ">=1.6.0" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=0.3.0" },
+    { name = "wasat", specifier = ">=0.3.1" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -1444,14 +1444,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/68/d00cba89f6b5f8dc50251db2547b5b954ec258850a5e6d9405718cc041b7/wasat-0.3.0.tar.gz", hash = "sha256:f5639ef07f889cd7b07fd11f2b4a45f438c84e4ee5b8b6b8f0d66639998cbc86", size = 19428, upload-time = "2026-07-11T13:31:59.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0b/94dab7266710829151b766d54b4b4980d095f1da5f23415146b318aac27c/wasat-0.3.1.tar.gz", hash = "sha256:0c269417849628c9b2e258f00e4aa7ecd2f083f0ea51d3a4f52e78f7f8ed41a6", size = 19936, upload-time = "2026-07-11T15:46:04.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/60/fa0b2bc90f33c2ad02941ab437d87e7379eb022f7c2e1e1b6c6e5ba3cf82/wasat-0.3.0-py3-none-any.whl", hash = "sha256:b734cbfe680181999832bb94ed021b379f20c1b4d3510fed1a758157de12a4ca", size = 23495, upload-time = "2026-07-11T13:31:57.939Z" },
+    { url = "https://files.pythonhosted.org/packages/87/98/5b3af0123466551765a2eac32d745402c6c373fe08336d933855bb31aeb1/wasat-0.3.1-py3-none-any.whl", hash = "sha256:3648077870b65ecbe6b0f94337946219b68fb684aea3ed586ada3ec599522fa4", size = 23886, upload-time = "2026-07-11T15:46:03.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumping Wasat with some extra testing and ideas for how to handle client certificates.

The issue I have, and I'm not sure how to resolve, is this: there's a site I'm testing with where you first encounter `example.com/join/`. The certificate will be created at that point, and will be scoped to `example.com/join/` because that's where it's created. This seems to match what the Gemini protocol documentation says should happen:

> The content requires a client certificate. The client MUST provide a certificate in order to access the content and SHOULD NOT repeat the request without one. The scope of a certificate generated in response to this status code should be limited to the host and port from which the status code was received and the path of the URL in the original request plus all paths below it. A server MAY require a different certificate for a different path on the same host and port. A server SHOULD allow the same certificate to be used for any content along the given path. Examples:
```
gemini://example.com/private/      -- requires certificate A
gemini://example.com/private/r1    -- requires certificate A
gemini://example.com/private/r2/r3 -- requires certificate A
gemini://example.com/other/        -- requires certificate B
gemini://example.com/other/r1      -- requires certificate B
gemini://example.com/other/r2/r3   -- requires certificate B
gemini://example.com/random	       -- no certificate required
```
> Clients MUST NOT automatically generate a client certificate and use it to repeat the request without the active involvement of the user. Clients MUST NOT use a client certificate generated in response to this status code for a request to a different host, a different port, or a path on the same host and port which is above the path of the URL in the original request unless directed to do so by the user.

So as I read this: a certificate created for /private should not be used for a requirement for a certificate created for /other, as in when created in a client application (with the user's consent). So one should be scoped to /private, the other scoped to /other. The user could elect to change the scope, presumably, but there's no sensible way of seamlessly doing this.

On the other hang Lagrange *does* seem to do this seamlessly, which sort of suggests it isn't following the rules given above. I doubt this, of course, which has me thinking I'm misreading something.

---

After some more digging I'm sure my reading is correct, and it seems it's a reasonably well-known issue with debatable outcomes. It looks like Lagrange takes a more-helpful approach to this. I might have to think about extending the way I do certificates to make it easy for the user to "promote" a certificate to a higher scope, if they run into problems (or, somehow, automatically promote a certificate if there's a creation followed by a redirection).