### PR TITLE
Relax scope of client certs by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "textual>=8.2.7",
     "textual-enhanced>=1.6.0",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=0.3.2",
+    "wasat>=0.4.0",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/src/rogallo/screens/certificate.py
+++ b/src/rogallo/screens/certificate.py
@@ -101,6 +101,12 @@ class Certificate(ModalScreen[CertificateData | None]):
             )
             with Collapsible(title="Advanced options"):
                 yield Checkbox(
+                    "Scope to domain/port [dim](ignores the path when scoping)[/]",
+                    True,
+                    id="scope-to-domain",
+                    classes="leave-room",
+                )
+                yield Checkbox(
                     "Transient [dim](not saved to disk)[/]",
                     id="transient",
                     classes="leave-room",
@@ -154,11 +160,24 @@ class Certificate(ModalScreen[CertificateData | None]):
         if value := self.query_one(f"#{key}", Input).value.strip():
             data[key] = value
 
+    def _scoped_location(self) -> GeminiURI:
+        """Returns the location scoped as per the user's choice.
+
+        Returns:
+            The location to scope the certificate to.
+        """
+        return (
+            self._location.with_path(None).with_query(None)
+            if self.query_one("#scope-to-domain", Checkbox).value
+            else self._location
+        )
+
     @on(Button.Pressed, "#create")
     def action_create(self) -> None:
         """Create the certificate."""
         certificate_data: CertificateData = {
-            "transient": self.query_one("#transient", Checkbox).value
+            "uri": self._scoped_location(),
+            "transient": self.query_one("#transient", Checkbox).value,
         }
         self._maybe_add(certificate_data, "common_name")
         try:

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -400,9 +400,7 @@ class Main(EnhancedScreen[None]):
         ) is None:
             self.notify("Client certificate request cancelled.", severity="warning")
             return
-        await self._client.client_cert_store.create_credentials(
-            uri=location, **certificate_data
-        )
+        await self._client.client_cert_store.create_credentials(**certificate_data)
         self.post_message(OpenLocation(location, allow_cached=False))
 
     async def _handle_response(self, response: Response, request: OpenLocation) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ requires-dist = [
     { name = "textual", specifier = ">=8.2.7" },
     { name = "textual-enhanced", specifier = ">=1.6.0" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=0.3.2" },
+    { name = "wasat", specifier = ">=0.4.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -1444,14 +1444,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/fd/b3c29ee1203170992608ddfc63edad93faa1be26ea0e766a068c5cfc8e26/wasat-0.3.2.tar.gz", hash = "sha256:399b0e32d239af16f013cbc816fc2fb307f1efbfc5024d53d7f796e6cf79963a", size = 20143, upload-time = "2026-07-11T18:07:09.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/01/652d9cfea4505eec0344f0cf06716edda3c36afdec34c22604f3c4dfb00e/wasat-0.4.0.tar.gz", hash = "sha256:948fc4975ce25ddf29c925cb912bbed80cb13e3a175c4f97955aa13ca572cd72", size = 20670, upload-time = "2026-07-12T08:43:43.845Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/38/12e049ef8a13dd34cf22e043105d88b77bed8f34c6d6f0194b8ba3be841e/wasat-0.3.2-py3-none-any.whl", hash = "sha256:54be0e7a1623c73a26c150e2b5648c2ed15549dbc6df5b9e296714567bdbdb58", size = 24101, upload-time = "2026-07-11T18:07:08.331Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f5/566c2ee7c5c1bac6486e6784659d4dc1e01e54a312871944fe547033d133/wasat-0.4.0-py3-none-any.whl", hash = "sha256:a9b01dc68c790898790fa24cffabebdac4e3f91fd7c906615c40461372186a91", size = 24629, upload-time = "2026-07-12T08:43:42.714Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The user still has the ability to apply strict scoping, as per the letter of the protocol specification, but by default the scope will be the host and the port alone.

Closes #121.