### PR TITLE
Reduce the list of default displayable content types

### DIFF
--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -32,7 +32,6 @@ class Configuration:
         default_factory=lambda: [
             "text/gemini",
             "text/plain",
-            "application/octet-stream",
         ]
     )
     """The content types that can be displayed in the viewer."""


### PR DESCRIPTION
I had application/octet-stream in the list early on while testing something, but I think it's a good idea to drop it now.