### PR TITLE
Update the default configuration for screenshots

### DIFF
--- a/docs/screenshots/support/maker.py
+++ b/docs/screenshots/support/maker.py
@@ -92,9 +92,10 @@ def make_app(viewing: str = "features"):
         config.disable_animations = True
         config.history_visible = False
         config.home_page = str(docs_dir / "examples/features.gmi")
+        config.stripe_links = False
         config.theme = "textual-mono"
         config.with_cache = False
-        config.stripe_links = False
+        config.with_link_jumps = True
     return Rogallo(
         Namespace(
             command="open",


### PR DESCRIPTION
For some reason the link jumps were appearing to be off, even though the default is for them to be on. This deserves a deeper dive, but for the moment I want the docs to show the correct screenshots so force the issue.