### PR TITLE
Add failed input recovery support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@
 - Added `jump_progress_timeout` to the configuration file to control the
   jump cancellation timeout.
   ([#167](https://github.com/davep/rogallo/pull/167))
+- If an input to a capsule fails for some reason, and the user tries to post
+  again, the input box is now pre-populated with the failed content for
+  further editing. ([#168](https://github.com/davep/rogallo/pull/168))
 
 ## v0.9.0
 

--- a/src/rogallo/input_content.py
+++ b/src/rogallo/input_content.py
@@ -1,0 +1,36 @@
+"""Provides a class for holding a user's input content."""
+
+##############################################################################
+# Python imports.
+from typing import NamedTuple
+
+##############################################################################
+# Wasat imports.
+from wasat import GeminiURI
+
+
+##############################################################################
+class InputContent(NamedTuple):
+    """A class for holding a user's input content."""
+
+    location: GeminiURI
+    """The location that the input was requested from."""
+    prompt: str
+    """The prompt that was shown to the user."""
+    sensitive: bool = False
+    """Whether the input is sensitive (e.g. a password)."""
+    content: str = ""
+    """The content of the input."""
+
+    def __eq__(self, other: object, /) -> bool:
+        """Check if two InputContent objects are equal."""
+        if isinstance(other, InputContent):
+            return (
+                self.location == other.location
+                and self.prompt == other.prompt
+                and self.sensitive == other.sensitive
+            )
+        return NotImplemented
+
+
+### input_content.py ends here

--- a/src/rogallo/messages/opening.py
+++ b/src/rogallo/messages/opening.py
@@ -11,6 +11,7 @@ from textual.message import Message
 ##############################################################################
 # Local imports.
 from ..document import Document
+from ..input_content import InputContent
 from ..types import GeminiLocation
 
 
@@ -36,6 +37,8 @@ class OpenLocation(Message):
     """Whether we should avoid recording this in history."""
     allow_cached: bool = True
     """Whether to allow opening the location from cache."""
+    associated_input: InputContent | None = None
+    """The input content associated with this location, if any."""
 
 
 ##############################################################################

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -93,6 +93,7 @@ from ..data import (
     update_configuration,
 )
 from ..document import Document
+from ..input_content import InputContent
 from ..messages import (
     CopyToClipboard,
     OpenDocument,
@@ -265,6 +266,8 @@ class Main(EnhancedScreen[None]):
         """The trusted schemes."""
         self._trusted_mime_types = load_trusted_mime_types()
         """The trusted MIME types."""
+        self._last_user_input: InputContent | None = None
+        """The last user input."""
         self._client = Client(
             verify_mode="tofu",
             trust_store_path=trust_file(),
@@ -393,12 +396,28 @@ class Main(EnhancedScreen[None]):
             location: The location making the request.
             sensitive: Whether the input is sensitive.
         """
+        initial_input = ""
+        if self._last_user_input and self._last_user_input == InputContent(
+            location=location, prompt=prompt, sensitive=sensitive
+        ):
+            initial_input = self._last_user_input.content
         if user_input := await self.app.push_screen_wait(
-            UserInput(location, prompt=prompt, sensitive=sensitive)
+            UserInput(
+                location, prompt=prompt, sensitive=sensitive, default=initial_input
+            )
         ):
             try:
                 self.post_message(
-                    OpenLocation(location.with_query(user_input), allow_cached=False)
+                    OpenLocation(
+                        location=location.with_query(user_input),
+                        allow_cached=False,
+                        associated_input=InputContent(
+                            location=location,
+                            prompt=prompt,
+                            sensitive=sensitive,
+                            content=user_input,
+                        ),
+                    )
                 )
             except URIError as error:
                 self.notify(
@@ -460,12 +479,16 @@ class Main(EnhancedScreen[None]):
 
         # Handle any other non-successful response.
         if not response.status.is_success:
+            self._last_user_input = request.associated_input
             self.notify(
                 f"Error loading {uri}:\n\n{response.status.value} {response.status.name}\n{response.meta}",
                 severity="error",
                 title="Request Error",
             )
             return
+
+        # Clear out any saved input.
+        self._last_user_input = None
 
         # Handle a successful response.
         if self._is_displayable(response.mime_type):
@@ -546,6 +569,7 @@ class Main(EnhancedScreen[None]):
             async with await self._client.request(uri) as response:
                 await self._handle_response(response, request)
         except ConnectionError as error:
+            self._last_user_input = request.associated_input
             self.notify(
                 f"Error loading {uri}:\n\n{error}",
                 severity="error",

--- a/src/rogallo/screens/user_input.py
+++ b/src/rogallo/screens/user_input.py
@@ -53,13 +53,16 @@ class UserInput(ModalScreen[str | None]):
     _input = query_one(TextArea)
     """The input text area."""
 
-    def __init__(self, location: GeminiURI, prompt: str, sensitive: bool) -> None:
+    def __init__(
+        self, location: GeminiURI, prompt: str, sensitive: bool, default: str = ""
+    ) -> None:
         """Initialise the object.
 
         Args:
             request_from: The request that prompted this input.
             prompt: The prompt to display to the user.
             sensitive: Whether the input is sensitive.
+            default: The default value to display in the input area.
         """
         super().__init__(classes=("--sensitive" if sensitive else ""))
         self._location = location
@@ -68,12 +71,16 @@ class UserInput(ModalScreen[str | None]):
         """The prompt to display to the user."""
         self._sensitive = sensitive
         """Whether the input is sensitive."""
+        self._default = default
+        """The default value to display in the input area."""
 
     def compose(self) -> ComposeResult:
         """Compose the input dialog."""
         yield (
             user_input := TextArea(
-                highlight_cursor_line=False, placeholder="Enter your input here..."
+                self._default,
+                highlight_cursor_line=False,
+                placeholder="Enter your input here...",
             )
         )
         user_input.border_title = Content(


### PR DESCRIPTION
It's a fairly simple approach, pretty much only good for the last failed input until there's any other good request. The idea being that if you input something, it fails, and you try again right away, you'll be prompted with the failed content you just submitted so you can edit it.

Closes #158.