### PR TITLE
Make search history/bookmarks into primary tools

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,10 @@
   ([#173](https://github.com/davep/rogallo/pull/173))
 - Added support for signifying if a link in a page has been visited before.
   ([#175](https://github.com/davep/rogallo/pull/175))
+- Made the command-palette-based interfaces for history and bookmarks the
+  primary interfaces, and turned the previous sidebar-based interfaces into
+  secondary "manager" tools.
+  ([#176](https://github.com/davep/rogallo/pull/176))
 
 ## v0.9.0
 

--- a/src/rogallo/commands/__init__.py
+++ b/src/rogallo/commands/__init__.py
@@ -15,8 +15,8 @@ from .main import (
     SetHome,
     SetHomeToCurrentLocation,
     StripeLinks,
-    ToggleBookmarks,
-    ToggleHistory,
+    ToggleBookmarksManager,
+    ToggleHistoryManager,
     ToggleLinkNumbers,
     ToggleView,
 )
@@ -45,8 +45,8 @@ __all__ = [
     "SetHome",
     "SetHomeToCurrentLocation",
     "StripeLinks",
-    "ToggleBookmarks",
-    "ToggleHistory",
+    "ToggleBookmarksManager",
+    "ToggleHistoryManager",
     "ToggleLinkNumbers",
     "ToggleView",
 ]

--- a/src/rogallo/commands/main.py
+++ b/src/rogallo/commands/main.py
@@ -34,21 +34,17 @@ class ChangeCommandLineLocation(Command):
 
 
 ##############################################################################
-class ToggleHistory(Command):
+class ToggleHistoryManager(Command):
     """Toggle the display of the history viewer"""
 
-    BINDING_KEY = "f2"
-    SHOW_IN_FOOTER = True
-    FOOTER_TEXT = "History"
+    BINDING_KEY = "shift+f2"
 
 
 ##############################################################################
-class ToggleBookmarks(Command):
+class ToggleBookmarksManager(Command):
     """Toggle the display of the bookmarks viewer"""
 
-    BINDING_KEY = "f3"
-    SHOW_IN_FOOTER = True
-    FOOTER_TEXT = "Bookmarks"
+    BINDING_KEY = "shift+f3"
 
 
 ##############################################################################

--- a/src/rogallo/commands/search.py
+++ b/src/rogallo/commands/search.py
@@ -9,14 +9,18 @@ from textual_enhanced.commands import Command
 class SearchHistory(Command):
     """Search the history for a location"""
 
-    BINDING_KEY = "f6"
+    BINDING_KEY = "f2"
+    SHOW_IN_FOOTER = True
+    FOOTER_TEXT = "History"
 
 
 ##############################################################################
 class SearchBookmarks(Command):
     """Search the bookmarks for a location"""
 
-    BINDING_KEY = "f7"
+    BINDING_KEY = "f3"
+    SHOW_IN_FOOTER = True
+    FOOTER_TEXT = "Bookmarks"
 
 
 ### search.py ends here

--- a/src/rogallo/providers/main.py
+++ b/src/rogallo/providers/main.py
@@ -32,8 +32,8 @@ from ..commands import (
     SetHome,
     SetHomeToCurrentLocation,
     StripeLinks,
-    ToggleBookmarks,
-    ToggleHistory,
+    ToggleBookmarksManager,
+    ToggleHistoryManager,
     ToggleLinkNumbers,
     ToggleView,
 )
@@ -71,8 +71,8 @@ class MainCommands(CommandsProvider):
         yield SetHome()
         yield from self.maybe(SetHomeToCurrentLocation)
         yield StripeLinks()
-        yield from self.maybe(ToggleBookmarks)
-        yield from self.maybe(ToggleHistory)
+        yield from self.maybe(ToggleBookmarksManager)
+        yield from self.maybe(ToggleHistoryManager)
         yield ToggleLinkNumbers()
         yield from self.maybe(ToggleView)
 

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -3,7 +3,7 @@
 ##############################################################################
 # Python imports.
 from argparse import Namespace
-from mimetypes import guess_type, knownfiles
+from mimetypes import guess_type
 from pathlib import Path
 from urllib.parse import urlparse
 from webbrowser import open as open_in_browser

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -3,7 +3,7 @@
 ##############################################################################
 # Python imports.
 from argparse import Namespace
-from mimetypes import guess_type
+from mimetypes import guess_type, knownfiles
 from pathlib import Path
 from urllib.parse import urlparse
 from webbrowser import open as open_in_browser
@@ -65,8 +65,8 @@ from ..commands import (
     SetHome,
     SetHomeToCurrentLocation,
     StripeLinks,
-    ToggleBookmarks,
-    ToggleHistory,
+    ToggleBookmarksManager,
+    ToggleHistoryManager,
     ToggleLinkNumbers,
     ToggleView,
 )
@@ -200,8 +200,8 @@ class Main(EnhancedScreen[None]):
         # Keep these together as they're bound to function keys and destined
         # for the footer.
         Help,
-        ToggleHistory,
-        ToggleBookmarks,
+        SearchHistory,
+        SearchBookmarks,
         Backward,
         Forward,
         Quit,
@@ -215,14 +215,14 @@ class Main(EnhancedScreen[None]):
         Reload,
         CopyDocumentToClipboard,
         CopyLocationToClipboard,
+        ToggleBookmarksManager,
+        ToggleHistoryManager,
         ToggleView,
         GoHome,
         GoToParent,
         GoToRoot,
         SetHome,
         SetHomeToCurrentLocation,
-        SearchHistory,
-        SearchBookmarks,
         StripeLinks,
         ClearCache,
         ToggleLinkNumbers,
@@ -356,9 +356,19 @@ class Main(EnhancedScreen[None]):
             return self._navigation_history.can_go_backward or None
         if action == Forward.action_name():
             return self._navigation_history.can_go_forward or None
-        if action in (ToggleHistory.action_name(), SearchHistory.action_name()):
+        if action == ToggleHistoryManager.action_name():
             return len(self._location_history) > 0 or None
-        if action in (ToggleBookmarks.action_name(), SearchBookmarks.action_name()):
+        if action == SearchHistory.action_name():
+            return (
+                len(self._location_history) > 0
+                or len(self._navigation_history) > 0
+                or len(HistorySearchCommands.known_hosts) > 0
+                or None
+            )
+        if action in (
+            ToggleBookmarksManager.action_name(),
+            SearchBookmarks.action_name(),
+        ):
             return len(self._bookmarks) > 0 or None
         if action in (
             Reload.action_name(),
@@ -882,8 +892,8 @@ class Main(EnhancedScreen[None]):
             )
             self.mutate_reactive(Main._navigation_history)
 
-    def action_toggle_history_command(self) -> None:
-        """Toggle the visibility of the history panel."""
+    def action_toggle_history_manager_command(self) -> None:
+        """Toggle the visibility of the history manager panel."""
         if self._history_visible:
             self._history_visible = not self._history_viewer.has_focus
         else:
@@ -895,8 +905,8 @@ class Main(EnhancedScreen[None]):
         if self._history_visible and self._bookmarks_visible:
             self._bookmarks_visible = False
 
-    def action_toggle_bookmarks_command(self) -> None:
-        """Toggle the visibility of the bookmarks panel."""
+    def action_toggle_bookmarks_manager_command(self) -> None:
+        """Toggle the visibility of the bookmarks manager panel."""
         if self._bookmarks_visible:
             self._bookmarks_visible = not self._bookmarks_viewer.has_focus
         else:


### PR DESCRIPTION
Turned the sidebar-based interfaces to history and bookmarks into secondary interfaces related to managing the lists. The palette-based search interfaces are now the primary ones.