### PR TITLE
Prefer location history over navigation history in search

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Rogallo ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Prioritise showing locations from history rather than navigation history
+  when doing a history search.
+  ([#198](https://github.com/davep/rogallo/pull/198))
+
 ## v0.12.0
 
 **Released: 2026-07-20**

--- a/src/rogallo/providers/history.py
+++ b/src/rogallo/providers/history.py
@@ -101,8 +101,8 @@ class HistorySearchCommands(CommandsProvider):
             set(
                 Historical(location)
                 for location in chain(
-                    self.navigation_history,
                     self.location_history,
+                    self.navigation_history,
                     (KnownHost(host) for host in self.known_hosts),
                 )
             )


### PR DESCRIPTION
The latter is still used, but if a location is in both lists, the one in the location history (and so has the time last visited available for display) is used.