### PR TITLE
Allow setting a Rogallo-specific external editor

### DIFF
--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -466,4 +466,21 @@ Here's a sample of some of the themes:
 ```{.textual path="docs/screenshots/main_screenshot.py" title="dracula" lines=35 columns=90 press="f9,d,r,a,c,u,l,a,enter"}
 ```
 
+## User input editor
+
+Rogallo supports using your choice of external text editor to edit user
+input. By default the input dialog will look to see if `$VISUAL` or
+`$EDITOR` are set in the environment and, if they are, you can press
+<kbd>F3</kbd> when editing input to open your editor.
+
+If you would prefer to set a specific editor for Rogallo itself, you can set
+`external_editor` in the configuration file. By default it is `null` (in
+which case it will look for `$VISUAL` and then `$EDITOR`):
+
+```json
+"external_editor": null
+```
+
+Set it to the program to run to use that specific editor for Rogallo.
+
 [//]: # (configuration.md ends here)

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -103,6 +103,9 @@ class Configuration:
     list_item_bullet_icon: str = "•"
     """The icon to use for list item bullets."""
 
+    external_editor: str | None = None
+    """The external editor to use for editing text content."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/screens/user_input.py
+++ b/src/rogallo/screens/user_input.py
@@ -22,6 +22,7 @@ from wasat import GeminiURI
 
 ##############################################################################
 # Local imports.
+from ..data import load_configuration
 from ..types import DEFAULT_GEMINI_EXTENSION
 
 
@@ -113,7 +114,12 @@ class UserInput(ModalScreen[str | None]):
     @property
     def _external_editor(self) -> str | None:
         """The external editor to use, if any."""
-        return getenv("VISUAL") or getenv("EDITOR") or None
+        return (
+            load_configuration().external_editor
+            or getenv("VISUAL")
+            or getenv("EDITOR")
+            or None
+        )
 
     def _update_subtitle(self) -> None:
         """Update the subtitle of the input area."""


### PR DESCRIPTION
If the user doesn't want to set `VISUAL` or `EDITOR`, or if they simply want a Rogallo-specific override anyway, allow setting it in the config file.