### PR TITLE
Add support for blending the background of some pre-formatted text

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,9 @@
   ([#211](https://github.com/davep/rogallo/pull/211))
 - Added support for using `$VISUAL` or `$EDITOR` to edit user input.
   ([#212](https://github.com/davep/rogallo/pull/212))
+- Added support for blending the background of some pre-formatted text
+  blocks with the background of the viewer.
+  ([#215](https://github.com/davep/rogallo/pull/215))
 
 ## v1.0.0
 

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -106,6 +106,9 @@ class Configuration:
     external_editor: str | None = None
     """The external editor to use for editing text content."""
 
+    blend_pre_formatted_with_background: list[str] = field(default_factory=lambda: [""])
+    """List of types of pre-formatted text to blend with the background."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/widgets/viewer/gemtext/preformatted.py
+++ b/src/rogallo/widgets/viewer/gemtext/preformatted.py
@@ -44,16 +44,32 @@ def _supported_language(language: str) -> bool:
 
 
 ##############################################################################
+@cache
+def _blended_types() -> set[str]:
+    """Get the set of preformatted types that should be blended with the background.
+
+    Returns:
+        The set of preformatted types that should be blended with the background.
+    """
+    return set(
+        alt_text.casefold()
+        for alt_text in load_configuration().blend_pre_formatted_with_background
+    )
+
+
+##############################################################################
 class GemtextPreformatted(Static):
     """A widget for displaying a Gemtext preformatted text block."""
 
     DEFAULT_CSS = """
     GemtextPreformatted {
         margin: 0 2;
-        background: black 35%;
         overflow: auto;
-        &:light {
-            background: white 35%;
+        &.--highlight {
+            background: black 35%;
+            &:light {
+                background: white 35%;
+            }
         }
     }
     """
@@ -67,7 +83,13 @@ class GemtextPreformatted(Static):
         assert isinstance(preformatted, PreFormatted)
         self._preformatted = preformatted
         """The Gemtext preformatted text to display."""
-        super().__init__()
+        super().__init__(
+            classes=(
+                ""
+                if preformatted.alt_text.casefold() in _blended_types()
+                else "--highlight"
+            )
+        )
         self.tooltip = (
             preformatted.alt_text
             if preformatted.has_alt_text


### PR DESCRIPTION
Based off the alt-text, decide if the background should be highlighted or should be the same as the viewer.

Closes #204.