### PR TITLE
Add support for command line aliases

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - Added optional configurable support for gopher type badges.
   ([#248](https://github.com/davep/rogallo/pull/248))
+- Added support for command line aliases.
+  ([#254](https://github.com/davep/rogallo/pull/254))
 
 ## v1.2.1
 

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -139,9 +139,10 @@ class Configuration:
 
     aliases: dict[str, str] = field(
         default_factory=lambda: {
+            "fg": "gopher://gopher.floodgap.com/1/v2/vs?{q}",
+            "gp": "gemini://gemi.dev/cgi-bin/wp.cgi/search?{q}",
             "ken": "gemini://kennedy.gemi.dev/search?{q}",
             "tlgs": "gemini://tlgs.one/search?{q}",
-            "fg": "gopher://gopher.floodgap.com/1/v2/vs?{q}",
         }
     )
     """Aliases to use in the command line."""

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -10,6 +10,8 @@ from json import dumps, loads
 from pathlib import Path
 from typing import Final
 
+##############################################################################
+# GopherMap imports.
 from gophermap import ItemType
 
 ##############################################################################

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -137,6 +137,15 @@ class Configuration:
     )
     """The badges to use for Gopher item types."""
 
+    aliases: dict[str, str] = field(
+        default_factory=lambda: {
+            "ken": "gemini://kennedy.gemi.dev/search?{q}",
+            "tlgs": "gemini://tlgs.one/search?{q}",
+            "fg": "gopher://gopher.floodgap.com/1/v2/vs?{q}",
+        }
+    )
+    """Aliases to use in the command line."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/widgets/command_line/aliases.py
+++ b/src/rogallo/widgets/command_line/aliases.py
@@ -1,0 +1,39 @@
+"""Provides code for expanding command line aliases."""
+
+##############################################################################
+# Python imports.
+from string import Formatter
+from urllib.parse import quote, quote_plus
+
+##############################################################################
+# Local imports.
+from ...data import load_configuration
+
+
+##############################################################################
+def expand_aliases(command_line: str) -> str:
+    """Expand command line aliases.
+
+    Args:
+        command_line: The command line to expand.
+
+    Returns:
+        The expanded command line.
+    """
+    aliases = load_configuration().aliases
+    car, _, cdr = command_line.partition(" ")
+    if car in aliases:
+        cdr = cdr.strip()
+        command_line = Formatter().vformat(
+            aliases[car],
+            (),
+            {
+                "q": quote(cdr),
+                "qp": quote_plus(cdr),
+                "r": cdr,
+            },
+        )
+    return command_line
+
+
+### aliases.py ends here

--- a/src/rogallo/widgets/command_line/widget.py
+++ b/src/rogallo/widgets/command_line/widget.py
@@ -36,6 +36,7 @@ from wasat import GeminiURI
 # Local imports.
 from ...data import Bookmarks, CommandLineHistory, LocationHistory, NavigationHistory
 from ...types import short_location
+from .aliases import expand_aliases
 from .base_command import InputCommand
 from .finger import FingerCommand
 from .general import ChangeThemeCommand, HelpCommand, QuitCommand, UnknownCommand
@@ -248,7 +249,7 @@ class CommandLine(Vertical):
         Args:
             command: The command the user entered.
         """
-        if not (command := command.strip()):
+        if not (command := expand_aliases(command.strip())):
             return
         for candidate in COMMANDS:
             if candidate.handle(command, self):

--- a/src/rogallo/widgets/command_line/widget.py
+++ b/src/rogallo/widgets/command_line/widget.py
@@ -34,7 +34,13 @@ from wasat import GeminiURI
 
 ##############################################################################
 # Local imports.
-from ...data import Bookmarks, CommandLineHistory, LocationHistory, NavigationHistory
+from ...data import (
+    Bookmarks,
+    CommandLineHistory,
+    LocationHistory,
+    NavigationHistory,
+    load_configuration,
+)
 from ...types import short_location
 from .aliases import expand_aliases
 from .base_command import InputCommand
@@ -119,12 +125,26 @@ class CommandLine(Vertical):
     | --      | --      | --        | --          |
     {cli_commands}
 
+    ### User-supplied command aliases
+
+    | Alias | Expansion |
+    | --    | --        |
+    {aliases}
+
     ### Special keys
 
     Special keys while in the command line:
     """.format(
         cli_commands="\n    ".join(
             sorted(chain(*(command.help_text() for command in COMMANDS)))
+        ),
+        aliases="\n    ".join(
+            sorted(
+                f"| {alias} | {expansion} |"
+                for alias, expansion in load_configuration().aliases.items()
+            )
+            if load_configuration().aliases
+            else ["| (none) | (none) |"]
         ),
     )
 


### PR DESCRIPTION
Adds support for a simple alias system for the command line, with some search-engine-oriented details. Defined in the configuration file like this:

```json
    "aliases": {
        "ken": "gemini://kennedy.gemi.dev/search?{q}",
        "tlgs": "gemini://tlgs.one/search?{q}",
        "fg": "gopher://gopher.floodgap.com/1/v2/vs?{q}"
    }
```

Parameters are:

- `{q}` for quoted parameter tail where spaces become `%20`
- `{qp}` for quoted parameter tail where spaces become `+`
- `{r}` for the raw parameter tail

An alias is expanded by simply partitioning an input command on the first space, trimming the tail, looking the text before the space up in the list of aliases and then formatting the expansion.

Inspired by #252.
Closes #253.