### PR TITLE
Certificate verification improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@
 
 - Fixed a crash if an alias had an unknown parameter in its expansion.
   ([#263](https://github.com/davep/rogallo/pull/263))
+- Made improvements to how hosts are verified, using a hybrid CA falling
+  back to TOFU approach. ([#264](https://github.com/davep/rogallo/pull/264))
+- Added an icon to the top of the viewer to say if a server has been
+  verified via CA or via TOFU.
+  ([#264](https://github.com/davep/rogallo/pull/264))
 
 ## v1.3.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "textual-fspicker>=1.0.1",
     "types-pygments>=2.20.0.20260518",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=1.3.0",
+    "wasat>=1.3.1",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "textual-fspicker>=1.0.1",
     "types-pygments>=2.20.0.20260518",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=1.0.1",
+    "wasat>=1.2.0",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "textual-fspicker>=1.0.1",
     "types-pygments>=2.20.0.20260518",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=1.2.0",
+    "wasat>=1.3.0",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/src/rogallo/cache.py
+++ b/src/rogallo/cache.py
@@ -85,6 +85,7 @@ class ContentCache(CacheManager):
                 original_location=GeminiURI(meta_data.get("original_location", uri)),
                 content=content_file.read_text(encoding="utf-8"),
                 mime_type=meta_data.get("mime_type"),
+                verification_method=meta_data.get("verification_method"),
                 from_cache=True,
             )
         except OSError:
@@ -117,6 +118,7 @@ class ContentCache(CacheManager):
                         "location": str(document.location),
                         "original_location": str(document.original_location),
                         "mime_type": document.mime_type,
+                        "verification_method": document.verification_method,
                         "cached_at": datetime.now().isoformat(),
                     },
                     indent=4,

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -111,6 +111,21 @@ class Configuration:
     list_item_bullet_icon: str = "•"
     """The icon to use for list item bullets."""
 
+    client_certificate_used_icon: str = "⚿"
+    """The icon to use for indicating that a client certificate was used."""
+
+    verified_ca_icon: str = "⛉"
+    """The icon to use for indicating that a server was verified by a CA."""
+
+    verified_tofu_icon: str = "✓"
+    """The icon to use for indicating that a server was verified by TOFU."""
+
+    verified_off_icon: str = "✗"
+    """The icon to use for indicating that server was off."""
+
+    verified_none_icon: str = " "
+    """The icon to use for indicating that a server was not verified."""
+
     external_editor: str | None = None
     """The external editor to use for editing text content."""
 

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass, field, fields
 from functools import cache
 from json import dumps, loads
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
 
 ##############################################################################
 # GopherMap imports.
@@ -65,6 +65,12 @@ class Configuration:
 
     cache_ttl: int = 3_600
     """The time-to-live for cached content, in seconds."""
+
+    capsule_certificate_verify_mode: Literal["ca", "tofu", "hybrid", "off"] = "hybrid"
+    """The certificate verification mode Gemini capsules.
+
+    One of: `ca`, `tofu`, `hybrid` or `off`.
+    """
 
     connection_timeout: int = 10
     """The connection timeout for network requests, in seconds."""

--- a/src/rogallo/document.py
+++ b/src/rogallo/document.py
@@ -10,6 +10,10 @@ from functools import cached_property
 from gophermap import GopherMap, ItemType
 
 ##############################################################################
+# Wasat imports.
+from wasat import VerificationMethod
+
+##############################################################################
 # Local imports.
 from .types import RogalloLocation, is_gemini_mime_type, is_gopher_mime_type
 
@@ -45,6 +49,9 @@ class Document:
 
     needed_certificate: bool = False
     """Whether the document required a client certificate to access."""
+
+    verification_method: VerificationMethod | None = None
+    """The method used to verify the server, if any."""
 
     def __bool__(self) -> bool:
         """Return `True` if the document has content, `False` otherwise."""

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -305,7 +305,7 @@ class Main(EnhancedScreen[None]):
         self._last_user_input: InputContent | None = None
         """The last user input."""
         self._gemini_client = GeminiClient(
-            verify_mode="tofu",
+            verify_mode=load_configuration().capsule_certificate_verify_mode,
             trust_store_path=trust_file(),
             client_cert_store_path=client_certificates_directory(),
             connect_timeout=load_configuration().connection_timeout,

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -578,6 +578,7 @@ class Main(EnhancedScreen[None]):
                             content=await response.text(),
                             mime_type=response.mime_type,
                             needed_certificate=response.client_cert_used,
+                            verification_method=response.verification_method,
                         )
                     ),
                     original_request=request,

--- a/src/rogallo/widgets/viewer/title.py
+++ b/src/rogallo/widgets/viewer/title.py
@@ -31,8 +31,17 @@ class ViewerTitle(Horizontal):
 
         #verification-method, #lock-icon {
             width: 2;
-            color: $text-success;
             padding-right: 1;
+        }
+
+        .--verified-ca, #lock-icon {
+            color: $text-success;
+        }
+        .--verified-tofu {
+            color: $text-warning;
+        }
+        .--verified-off, .--verified-none {
+            color: $text-error;
         }
 
         #location {
@@ -85,6 +94,9 @@ class ViewerTitle(Horizontal):
 
     def _watch_verification_method(self) -> None:
         """React to the verification_method changing."""
+        self._verification_method_icon.set_classes(
+            f"--verified-{str(self.verification_method).lower()}"
+        )
         match self.verification_method:
             case "ca":
                 self._verification_method_icon.update(

--- a/src/rogallo/widgets/viewer/title.py
+++ b/src/rogallo/widgets/viewer/title.py
@@ -9,6 +9,10 @@ from textual.reactive import var
 from textual.widgets import Label
 
 ##############################################################################
+# Wasat imports.
+from wasat import VerificationMethod
+
+##############################################################################
 # Local imports.
 from ...types import RogalloLocation
 
@@ -24,9 +28,10 @@ class ViewerTitle(Horizontal):
         height: 1;
         padding: 0 1;
 
-        #lock-icon {
-            width: 1;
+        #verification-method, #lock-icon {
+            width: 2;
             color: $text-success;
+            padding-right: 1;
         }
 
         #location {
@@ -38,9 +43,13 @@ class ViewerTitle(Horizontal):
 
     location: var[RogalloLocation | None] = var(None, always_update=True)
     """The location to display."""
+    verification_method: var[VerificationMethod | None] = var(None)
+    """The verification method used for the connection."""
     needed_certificate: var[bool] = var(False)
     """Whether the location needed a certificate."""
 
+    _verification_method_icon = query_one("#verification-method", Label)
+    """The label for the verification method."""
     _lock_icon = query_one("#lock-icon", Label)
     """The label for the lock icon."""
     _location_label = query_one("#location", Label)
@@ -48,6 +57,7 @@ class ViewerTitle(Horizontal):
 
     def compose(self) -> ComposeResult:
         """Compose the child widgets."""
+        yield Label(id="verification-method")
         yield Label(id="lock-icon")
         yield Label(id="location")
 
@@ -67,6 +77,16 @@ class ViewerTitle(Horizontal):
     def _watch_needed_certificate(self) -> None:
         """React to the needed_certificate changing."""
         self._lock_icon.update("\u26bf" if self.needed_certificate else " ")
+
+    def _watch_verification_method(self) -> None:
+        """React to the verification_method changing."""
+        match self.verification_method:
+            case "ca":
+                self._verification_method_icon.update("⛉")
+            case "tofu":
+                self._verification_method_icon.update("✓")
+            case _:
+                self._verification_method_icon.update(" ")
 
     def on_resize(self) -> None:
         """Handle the widget being resized."""

--- a/src/rogallo/widgets/viewer/title.py
+++ b/src/rogallo/widgets/viewer/title.py
@@ -14,6 +14,7 @@ from wasat import VerificationMethod
 
 ##############################################################################
 # Local imports.
+from ...data import load_configuration
 from ...types import RogalloLocation
 
 
@@ -76,17 +77,31 @@ class ViewerTitle(Horizontal):
 
     def _watch_needed_certificate(self) -> None:
         """React to the needed_certificate changing."""
-        self._lock_icon.update("\u26bf" if self.needed_certificate else " ")
+        self._lock_icon.update(
+            load_configuration().client_certificate_used_icon
+            if self.needed_certificate
+            else " "
+        )
 
     def _watch_verification_method(self) -> None:
         """React to the verification_method changing."""
         match self.verification_method:
             case "ca":
-                self._verification_method_icon.update("⛉")
+                self._verification_method_icon.update(
+                    load_configuration().verified_ca_icon
+                )
             case "tofu":
-                self._verification_method_icon.update("✓")
+                self._verification_method_icon.update(
+                    load_configuration().verified_tofu_icon
+                )
+            case "off":
+                self._verification_method_icon.update(
+                    load_configuration().verified_off_icon
+                )
             case _:
-                self._verification_method_icon.update(" ")
+                self._verification_method_icon.update(
+                    load_configuration().verified_none_icon
+                )
 
     def on_resize(self) -> None:
         """Handle the widget being resized."""

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -175,6 +175,7 @@ class Viewer(Vertical, can_focus=False):
         """
         if old_document.location != new_document.location:
             self.set_reactive(Viewer.view_source, False)
+        self._title.verification_method = self.document.verification_method
         self._title.needed_certificate = self.document.needed_certificate
         self._title.location = self.document.location
         self._status.mime_type = self.document.mime_type or ""

--- a/uv.lock
+++ b/uv.lock
@@ -546,11 +546,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.32.0"
+version = "3.32.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
 ]
 
 [[package]]
@@ -1601,7 +1601,7 @@ requires-dist = [
     { name = "textual-fspicker", specifier = ">=1.0.1" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=1.0.1" },
+    { name = "wasat", specifier = ">=1.2.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -1790,14 +1790,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "1.0.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/d1/800c72a488c81eda70876e04fc275e6a0a5f8daecb9e24e1da42632aaf95/wasat-1.0.1.tar.gz", hash = "sha256:426e7ce950eb3f84715c0fb59550cb349ef20f7abb88f90aa603147860725256", size = 22034, upload-time = "2026-07-21T18:45:38.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/37/687e44f28f00343ba638d5ed1acb20665968ee0edf57748a3c3caf610134/wasat-1.2.0.tar.gz", hash = "sha256:cf70877c09141d7afa413f466b1f795deb291614482c4760b1a80b273c855860", size = 22502, upload-time = "2026-07-30T07:44:50.556Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/26/8023b8692647fffad0142feac8751e9cda0836825b8fddde57a540e3e5b3/wasat-1.0.1-py3-none-any.whl", hash = "sha256:30153a1f25f833282cdb317438930fd9fc5ce2e191d13f0170d628bc7bacd561", size = 26100, upload-time = "2026-07-21T18:45:37.756Z" },
+    { url = "https://files.pythonhosted.org/packages/54/aa/a35db5add802257e86d866b315261a74bad833c6ce0b943c577aa45b1390/wasat-1.2.0-py3-none-any.whl", hash = "sha256:17a7e8d334db85e7f6b7827d3fe39e112fe35d842ef48bd02e0eadbd53431288", size = 26383, upload-time = "2026-07-30T07:44:49.535Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1601,7 +1601,7 @@ requires-dist = [
     { name = "textual-fspicker", specifier = ">=1.0.1" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=1.3.0" },
+    { name = "wasat", specifier = ">=1.3.1" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -1775,7 +1775,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.7.0"
+version = "21.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1783,21 +1783,21 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/fa/18004e5cb15541ad2a68ff219c755233b012b12d4ec8663d06a258082bec/virtualenv-21.7.1.tar.gz", hash = "sha256:d0dbfaa5483487baea28d7210ef8d24c9d1bd0f10f449eeb215568825a9b334e", size = 5525237, upload-time = "2026-07-30T15:40:36.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl", hash = "sha256:6394973f990536e34c05157179146c020284c42fe01da1dfeb0ba16c345280d9", size = 5504576, upload-time = "2026-07-30T15:40:34.512Z" },
 ]
 
 [[package]]
 name = "wasat"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/e3/076572f3b90cd34cf992343d074a77cfe391dff5233a1dff46fa9da75bd4/wasat-1.3.0.tar.gz", hash = "sha256:5f82c5ae7c419e21c0ea9beebbb3015797365826e0298a0971e21a85e99e272f", size = 23799, upload-time = "2026-07-30T14:57:33.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/c4/d2c36778782be4338750f40b6fce623a6208f54ac796d67b1562ef9e3c23/wasat-1.3.1.tar.gz", hash = "sha256:6c1c7f2dc40e5a0abeaad9495331a640f69b1051684de1283951d197eafa73d5", size = 24847, upload-time = "2026-07-30T18:32:10.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/33/13d1f56d83d50592a5b15e729f3f92cb6f1eb107ebc7e4c74e16aaae7625/wasat-1.3.0-py3-none-any.whl", hash = "sha256:e290d388576b348dd4f910e3b267b05e46b9f36d69bd4243e1c3b51ac0dd7992", size = 27675, upload-time = "2026-07-30T14:57:32.648Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d0/d19146930c807d0d401a2ddf34c4cbdb1f9da331462b33d329f6dffae228/wasat-1.3.1-py3-none-any.whl", hash = "sha256:40a47a808c3c1b53941b1d0c0645e275497e1c0ab22a5874603a7f19e05710b6", size = 28824, upload-time = "2026-07-30T18:32:09.612Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1601,7 +1601,7 @@ requires-dist = [
     { name = "textual-fspicker", specifier = ">=1.0.1" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=1.2.0" },
+    { name = "wasat", specifier = ">=1.3.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -1790,14 +1790,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/37/687e44f28f00343ba638d5ed1acb20665968ee0edf57748a3c3caf610134/wasat-1.2.0.tar.gz", hash = "sha256:cf70877c09141d7afa413f466b1f795deb291614482c4760b1a80b273c855860", size = 22502, upload-time = "2026-07-30T07:44:50.556Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e3/076572f3b90cd34cf992343d074a77cfe391dff5233a1dff46fa9da75bd4/wasat-1.3.0.tar.gz", hash = "sha256:5f82c5ae7c419e21c0ea9beebbb3015797365826e0298a0971e21a85e99e272f", size = 23799, upload-time = "2026-07-30T14:57:33.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/aa/a35db5add802257e86d866b315261a74bad833c6ce0b943c577aa45b1390/wasat-1.2.0-py3-none-any.whl", hash = "sha256:17a7e8d334db85e7f6b7827d3fe39e112fe35d842ef48bd02e0eadbd53431288", size = 26383, upload-time = "2026-07-30T07:44:49.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/33/13d1f56d83d50592a5b15e729f3f92cb6f1eb107ebc7e4c74e16aaae7625/wasat-1.3.0-py3-none-any.whl", hash = "sha256:e290d388576b348dd4f910e3b267b05e46b9f36d69bd4243e1c3b51ac0dd7992", size = 27675, upload-time = "2026-07-30T14:57:32.648Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Provides improvements to the way that certificates are verified. While most of the work is [taking place in Wasat](https://github.com/davep/wasat) (see https://github.com/davep/wasat/pull/39 and https://github.com/davep/wasat/pull/41), this PR ensures that the correct lower-bound of Wasat is in place. Also:

- Adds a `capsule_certificate_verify_mode` configuration setting to allow for changing the verification mode. Normally a user would not want to change this, but I'm adding this as a diagnostic tool.
- The default mode has changed from `tofu` to `hybrid`.
- There's now an icon at the top of the browser to show what state we're in.

Examples of the icon include, TOFU, no client certificate.

<img width="49" height="36" alt="Screenshot 2026-07-30 at 16 56 12" src="https://github.com/user-attachments/assets/06bc7f3d-77d9-467d-818a-761b646f1f42" />

CA, client certificate in use.

<img width="59" height="32" alt="Screenshot 2026-07-30 at 16 55 43" src="https://github.com/user-attachments/assets/b8c031bb-0de7-4b07-94e3-58f07d876d56" />

TOFU, client certificate in use.

<img width="58" height="31" alt="Screenshot 2026-07-30 at 16 55 15" src="https://github.com/user-attachments/assets/82bde3c2-4446-49a1-bcb8-d9483129b98c" />

TODO:

- [x] If a page is loaded from cache, the verification method is not known. Perhaps either add an icon to show it's a page from cache, or perhaps store the verification method used to get the page into the metadata that goes into the cache, and then use that.
- [x] Consider making the TOFU icon a different colour from the CA icon (`$text-warning` for TOFU, `$text-success` for CA?).
- [x] Consider #265 and, if doing that work here, also make the icon clickable so that the information shows on click.

Closes #221.