### PR TITLE
Remove seeing ports for some protocols in the docs

### DIFF
--- a/docs/screenshots/support/maker.py
+++ b/docs/screenshots/support/maker.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from random import randint
 from typing import Any
 
+import port70.uri
+import port79.uri
+import sybaritic.uri
 from wasat import GeminiURI
 
 from rogallo.data import (
@@ -25,6 +28,13 @@ from rogallo.data import (
 )
 from rogallo.data.themes import themes_dir
 from rogallo.rogallo import Rogallo
+
+##############################################################################
+# Patch the ports for Gopher, Finger and Spartan so the screenshots don't
+# show non-standard ports.
+port70.uri.GOPHER_DEFAULT_PORT = 7070
+port79.uri.FINGER_DEFAULT_PORT = 7979
+sybaritic.uri.SPARTAN_DEFAULT_PORT = 3000
 
 ##############################################################################
 # Work our the root of the documentation directory and the build directory.

--- a/docs/source/finger.md
+++ b/docs/source/finger.md
@@ -18,14 +18,6 @@ the [command line](./command-line.md).
 ```{.textual path="docs/screenshots/empty_screenshot.py" title="After pressing Enter" lines=30 columns=90 press="f,i,n,g,e,r,:,/,/,l,o,c,a,l,h,o,s,t,:,7,9,7,9,/,d,a,v,e,p,enter"}
 ```
 
-!!! note
-
-    There is a small cheat in the above example. You'll notice the `7979` in
-    the URI in the second screenshot. This is simply down to that being the
-    port of the server used to generate this documentation. Under normal
-    circumstances you would not need to enter the port (which is `79` by
-    default, for Finger).
-
 ## Finger command
 
 There is also support for a `!finger` command in the [command

--- a/docs/source/gopher.md
+++ b/docs/source/gopher.md
@@ -12,14 +12,6 @@ wish to visit. Gopher URIs begin with `gopher://`.
 ```{.textual path="docs/screenshots/empty_screenshot.py" title="After pressing Enter" lines=30 columns=90 press="g,o,p,h,e,r,:,/,/,l,o,c,a,l,h,o,s,t,:,7,0,7,0,enter"}
 ```
 
-!!! note
-
-    There is a small cheat in the above example. You'll notice the `7070` in
-    the URI in the second screenshot. This is simply down to that being the
-    port of the server used to generate this documentation. Under normal
-    circumstances you would not need to enter the port (which is `70` by
-    default, for Gopher).
-
 ## Supported item types
 
 Rogallo has direct support for a number of Gopher item types. These types

--- a/docs/source/spartan.md
+++ b/docs/source/spartan.md
@@ -12,14 +12,6 @@ location you wish to visit. Spartan URIs begin with `spartan://`.
 ```{.textual path="docs/screenshots/empty_screenshot.py" title="After pressing Enter" lines=30 columns=90 press="s,p,a,r,t,a,n,:,/,/,l,o,c,a,l,h,o,s,t,:,3,0,0,0,enter"}
 ```
 
-!!! note
-
-    There is a small cheat in the above example. You'll notice the `3000` in
-    the URI in the second screenshot. This is simply down to that being the
-    port of the server used to generate this documentation. Under normal
-    circumstances you would not need to enter the port (which is `300` by
-    default, for Spartan).
-
 ## `spartan://` URIs
 
 Rogallo will handle any valid `spartan://` URI, either as a link to be


### PR DESCRIPTION
Monkey-patch the default ports for Gopher, Finger and Spartan, so the URIs look "clean" in the docs.

Closes #292.