### PR TITLE
Optionally add syntax highlighting to text views

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@
 - All `text/*` MIME types are now considered to be something that can be
   displayed within Rogallo.
   ([#293](https://github.com/davep/rogallo/pull/293))
+- Added optional syntax highlighting when visiting a non-Gemtext/Gopher
+  document whose content can be inferred.
+  ([#296](https://github.com/davep/rogallo/pull/296))
 
 ## v1.5.0
 

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -176,6 +176,9 @@ class Configuration:
     guess_language_for_syntax_highlighting_text_documents: bool = True
     """Whether to guess the language for syntax highlighting of text documents."""
 
+    second_guess_language_for_syntax_highlighting_text_documents: bool = True
+    """Should we try and guess the actual content of a text/plain document when syntax highlighting?"""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -176,9 +176,6 @@ class Configuration:
     guess_language_for_syntax_highlighting_text_documents: bool = True
     """Whether to guess the language for syntax highlighting of text documents."""
 
-    second_guess_language_for_syntax_highlighting_text_documents: bool = True
-    """Should we try and guess the actual content of a text/plain document when syntax highlighting?"""
-
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -173,6 +173,9 @@ class Configuration:
     )
     """Aliases to use in the command line."""
 
+    guess_language_for_syntax_highlighting_text_documents: bool = True
+    """Whether to guess the language for syntax highlighting of text documents."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/document.py
+++ b/src/rogallo/document.py
@@ -60,6 +60,14 @@ class Document:
         """Return `True` if the document has content, `False` otherwise."""
         return bool(self.content)
 
+    @cached_property
+    def mime_type_sans_parameters(self) -> str | None:
+        """The MIME type cleaned of any parameters.."""
+        if self.mime_type is None:
+            return None
+        mime_type, _, _ = self.mime_type.partition(";")
+        return mime_type.strip().lower()
+
     @property
     def is_gemtext(self) -> bool:
         """`True` if the document is a Gemtext document, `False` otherwise."""

--- a/src/rogallo/widgets/viewer/gemtext/preformatted.py
+++ b/src/rogallo/widgets/viewer/gemtext/preformatted.py
@@ -9,11 +9,6 @@ from functools import cache
 from gemtext import Line, PreFormatted
 
 ##############################################################################
-# Pygments imports.
-from pygments.lexers import get_lexer_by_name
-from pygments.util import ClassNotFound
-
-##############################################################################
 # Textual imports.
 from textual.app import ComposeResult
 from textual.highlight import HighlightTheme, highlight
@@ -22,25 +17,8 @@ from textual.widgets import Label, Static
 ##############################################################################
 # Local imports.
 from ....data import load_configuration
+from ..languages import supported_language
 from .content_filter import GemtextContent
-
-
-##############################################################################
-@cache
-def _supported_language(language: str) -> bool:
-    """Check if a language is supported by Pygments.
-
-    Args:
-        language: The language to check.
-
-    Returns:
-        True if the language is supported; False otherwise.
-    """
-    try:
-        _ = get_lexer_by_name(language)
-        return True
-    except ClassNotFound:
-        return False
 
 
 ##############################################################################
@@ -107,7 +85,7 @@ class GemtextPreformatted(Static):
                 theme=HighlightTheme,
             )
             if self._preformatted.has_alt_text
-            and _supported_language(self._preformatted.alt_text)
+            and supported_language(self._preformatted.alt_text)
             else text,
             markup=False,
         )

--- a/src/rogallo/widgets/viewer/languages.py
+++ b/src/rogallo/widgets/viewer/languages.py
@@ -6,8 +6,13 @@ from functools import cache
 
 ##############################################################################
 # Pygments imports.
-from pygments.lexers import get_lexer_by_name
+from pygments.lexers import get_lexer_by_name, get_lexer_for_mimetype, guess_lexer
 from pygments.util import ClassNotFound
+
+##############################################################################
+# Local imports.
+from ...data import load_configuration
+from ...document import Document
 
 
 ##############################################################################
@@ -26,6 +31,32 @@ def supported_language(language: str) -> bool:
     except ClassNotFound:
         return False
     return True
+
+
+##############################################################################
+def language_from_document(document: Document) -> str | None:
+    """Try and work out the language of a document.
+
+    Args:
+        document: The document to check.
+
+    Returns:
+        The language of the document, or None if it could not be determined.
+    """
+    # Try and work out from the MIME type first.
+    if document.mime_type is not None:
+        try:
+            return get_lexer_for_mimetype(document.mime_type).name.lower()
+        except ClassNotFound:
+            pass
+    # Allow not guessing.
+    if not load_configuration().guess_language_for_syntax_highlighting_text_documents:
+        return None
+    # Failing that, see if we can work out a good guess from the content.
+    try:
+        return guess_lexer(document.content).name.lower()
+    except ClassNotFound:
+        return None
 
 
 ### languages.py ends here

--- a/src/rogallo/widgets/viewer/languages.py
+++ b/src/rogallo/widgets/viewer/languages.py
@@ -3,6 +3,7 @@
 ##############################################################################
 # Python imports.
 from functools import cache
+from typing import Final
 
 ##############################################################################
 # Pygments imports.
@@ -34,6 +35,13 @@ def supported_language(language: str) -> bool:
 
 
 ##############################################################################
+_MIME_SWAPS: Final[dict[str, str]] = {
+    "text/markdown": "text/x-markdown",
+}
+"""Mapping of MIME types to their Pygments equivalents."""
+
+
+##############################################################################
 def language_from_document(document: Document) -> str | None:
     """Try and work out the language of a document.
 
@@ -43,15 +51,28 @@ def language_from_document(document: Document) -> str | None:
     Returns:
         The language of the document, or None if it could not be determined.
     """
+    # If we're looking at a plain text document, and if the user is cool
+    # with second-guessing the content, None out the type to force guessing.
+    if (
+        (mime_type := document.mime_type_sans_parameters) == "text/plain"
+        and load_configuration().guess_language_for_syntax_highlighting_text_documents
+        and load_configuration().second_guess_language_for_syntax_highlighting_text_documents
+    ):
+        mime_type = None
+
     # Try and work out from the MIME type first.
-    if document.mime_type is not None:
+    if mime_type is not None:
         try:
-            return get_lexer_for_mimetype(document.mime_type).name.lower()
+            return get_lexer_for_mimetype(
+                _MIME_SWAPS.get(mime_type, mime_type)
+            ).name.lower()
         except ClassNotFound:
             pass
+
     # Allow not guessing.
     if not load_configuration().guess_language_for_syntax_highlighting_text_documents:
         return None
+
     # Failing that, see if we can work out a good guess from the content.
     try:
         return guess_lexer(document.content).name.lower()

--- a/src/rogallo/widgets/viewer/languages.py
+++ b/src/rogallo/widgets/viewer/languages.py
@@ -36,6 +36,7 @@ def supported_language(language: str) -> bool:
 
 ##############################################################################
 _MIME_SWAPS: Final[dict[str, str]] = {
+    "application/octet-stream": "text/plain",
     "text/markdown": "text/x-markdown",
 }
 """Mapping of MIME types to their Pygments equivalents."""
@@ -51,17 +52,9 @@ def language_from_document(document: Document) -> str | None:
     Returns:
         The language of the document, or None if it could not be determined.
     """
-    # If we're looking at a plain text document, and if the user is cool
-    # with second-guessing the content, None out the type to force guessing.
-    if (
-        (mime_type := document.mime_type_sans_parameters) == "text/plain"
-        and load_configuration().guess_language_for_syntax_highlighting_text_documents
-        and load_configuration().second_guess_language_for_syntax_highlighting_text_documents
-    ):
-        mime_type = None
 
     # Try and work out from the MIME type first.
-    if mime_type is not None:
+    if (mime_type := document.mime_type_sans_parameters) is not None:
         try:
             return get_lexer_for_mimetype(
                 _MIME_SWAPS.get(mime_type, mime_type)

--- a/src/rogallo/widgets/viewer/languages.py
+++ b/src/rogallo/widgets/viewer/languages.py
@@ -23,9 +23,9 @@ def supported_language(language: str) -> bool:
     """
     try:
         _ = get_lexer_by_name(language)
-        return True
     except ClassNotFound:
         return False
+    return True
 
 
 ### languages.py ends here

--- a/src/rogallo/widgets/viewer/languages.py
+++ b/src/rogallo/widgets/viewer/languages.py
@@ -1,0 +1,31 @@
+"""Support tools for syntax highlighting."""
+
+##############################################################################
+# Python imports.
+from functools import cache
+
+##############################################################################
+# Pygments imports.
+from pygments.lexers import get_lexer_by_name
+from pygments.util import ClassNotFound
+
+
+##############################################################################
+@cache
+def supported_language(language: str) -> bool:
+    """Check if a language is supported by Pygments.
+
+    Args:
+        language: The language to check.
+
+    Returns:
+        True if the language is supported; False otherwise.
+    """
+    try:
+        _ = get_lexer_by_name(language)
+        return True
+    except ClassNotFound:
+        return False
+
+
+### languages.py ends here

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -3,7 +3,6 @@
 ##############################################################################
 # Python imports.
 from collections.abc import Iterator
-from typing import Final
 
 ##############################################################################
 # Gemtext imports.
@@ -47,7 +46,7 @@ from ...document import Document
 from .document_view import DocumentView
 from .gemtext import GemtextContent, GemtextLink, get_block_widget
 from .gopher import to_gemtext
-from .languages import supported_language
+from .languages import language_from_document
 from .status import ViewerStatus
 from .title import ViewerTitle
 
@@ -171,9 +170,6 @@ class Viewer(Vertical, can_focus=False):
         if buffer:
             yield Paragraph("\n".join(buffer))
 
-    _TEXT_X: Final[str] = "text/x-"
-    """The prefix for text mime types whose language we might be able to guess."""
-
     def _best_presentation_for(self, document: Document) -> list[Widget]:
         """Get the best presentation for the document.
 
@@ -184,13 +180,7 @@ class Viewer(Vertical, can_focus=False):
             The best presentation for the document.
         """
         content: str | Content
-        if (
-            document.mime_type
-            and document.mime_type.startswith(self._TEXT_X)
-            and supported_language(
-                language := document.mime_type.removeprefix(self._TEXT_X).strip()
-            )
-        ):
+        if language := language_from_document(document):
             content = highlight(
                 document.content, language=language, theme=HighlightTheme
             )

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -181,7 +181,8 @@ class Viewer(Vertical, can_focus=False):
         return [
             Static(
                 highlight(document.content, language=language, theme=HighlightTheme)
-                if (language := language_from_document(document))
+                if not self.view_source
+                and (language := language_from_document(document))
                 else self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}"),
                 markup=False,
             )

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -3,6 +3,7 @@
 ##############################################################################
 # Python imports.
 from collections.abc import Iterator
+from typing import Final
 
 ##############################################################################
 # Gemtext imports.
@@ -22,10 +23,13 @@ from sybaritic import SpartanURI
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import HorizontalGroup, Vertical
+from textual.content import Content
 from textual.events import DescendantBlur, DescendantFocus, Key
 from textual.getters import query_one
+from textual.highlight import HighlightTheme, highlight
 from textual.reactive import var
 from textual.timer import Timer
+from textual.widget import Widget
 from textual.widgets import Static
 
 ##############################################################################
@@ -43,6 +47,7 @@ from ...document import Document
 from .document_view import DocumentView
 from .gemtext import GemtextContent, GemtextLink, get_block_widget
 from .gopher import to_gemtext
+from .languages import supported_language
 from .status import ViewerStatus
 from .title import ViewerTitle
 
@@ -166,6 +171,33 @@ class Viewer(Vertical, can_focus=False):
         if buffer:
             yield Paragraph("\n".join(buffer))
 
+    _TEXT_X: Final[str] = "text/x-"
+    """The prefix for text mime types whose language we might be able to guess."""
+
+    def _best_presentation_for(self, document: Document) -> list[Widget]:
+        """Get the best presentation for the document.
+
+        Args:
+            document: The document to get the best presentation for.
+
+        Returns:
+            The best presentation for the document.
+        """
+        content: str | Content
+        if (
+            document.mime_type
+            and document.mime_type.startswith(self._TEXT_X)
+            and supported_language(
+                language := document.mime_type.removeprefix(self._TEXT_X).strip()
+            )
+        ):
+            content = highlight(
+                document.content, language=language, theme=HighlightTheme
+            )
+        else:
+            content = self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}")
+        return [Static(content, markup=False)]
+
     async def _watch_document(
         self, old_document: Document, new_document: Document
     ) -> None:
@@ -185,12 +217,7 @@ class Viewer(Vertical, can_focus=False):
             await self._view.remove_children()
             self._jump_map = {}
             await self._view.mount_all(
-                [
-                    Static(
-                        self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}"),
-                        markup=False,
-                    )
-                ]
+                self._best_presentation_for(self.document)
                 if not (
                     self.document.is_gemtext
                     or self.document.is_gophermap

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -22,7 +22,6 @@ from sybaritic import SpartanURI
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import HorizontalGroup, Vertical
-from textual.content import Content
 from textual.events import DescendantBlur, DescendantFocus, Key
 from textual.getters import query_one
 from textual.highlight import HighlightTheme, highlight
@@ -179,14 +178,14 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             The best presentation for the document.
         """
-        content: str | Content
-        if language := language_from_document(document):
-            content = highlight(
-                document.content, language=language, theme=HighlightTheme
+        return [
+            Static(
+                highlight(document.content, language=language, theme=HighlightTheme)
+                if (language := language_from_document(document))
+                else self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}"),
+                markup=False,
             )
-        else:
-            content = self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}")
-        return [Static(content, markup=False)]
+        ]
 
     async def _watch_document(
         self, old_document: Document, new_document: Document


### PR DESCRIPTION
For example, if we're visiting a document whose type is `text/x-python`, we can safely infer that it's Python code, so why not sprinkle some syntax highlighting over the display to make it more interesting?

Also, this change sets us up for richer display of other things based on their MIME type and perhaps just their content. For example, at this point, I could probably slow in full Markdown rendering for markdown documents.