### PR TITLE
Handle text files that contain ANSI escape sequences

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Rogallo ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Handle text files that contain ANSI escape sequences.
+  ([#300](https://github.com/davep/rogallo/pull/300))
+
 ## v1.6.0
 
 **Released: 2026-08-08**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - Handle text files that contain ANSI escape sequences.
   ([#300](https://github.com/davep/rogallo/pull/300))
+- Fixed gopher errors being detected in files that aren't gopher responses.
+  ([#300](https://github.com/davep/rogallo/pull/300))
 
 ## v1.6.0
 

--- a/src/rogallo/document.py
+++ b/src/rogallo/document.py
@@ -84,7 +84,7 @@ class Document:
         return ItemType.ERROR in {item.type for item in GopherMap(self.content).items}
 
     @property
-    def is_source(self) -> bool:
+    def is_renderable_as_gemtext(self) -> bool:
         """`True` if the document is a source code document, `False` otherwise."""
         return self.is_gemtext or self.is_gophermap or self.is_gopher_error
 

--- a/src/rogallo/document.py
+++ b/src/rogallo/document.py
@@ -10,6 +10,10 @@ from functools import cached_property
 from gophermap import GopherMap, ItemType
 
 ##############################################################################
+# Port70 imports.
+from port70 import GopherURI
+
+##############################################################################
 # Wasat imports.
 from wasat import ServerCertificate, VerificationMethod
 
@@ -81,7 +85,7 @@ class Document:
     @cached_property
     def is_gopher_error(self) -> bool:
         """`True` if the document is a Gopher error document, `False` otherwise."""
-        return self.is_gophermap and ItemType.ERROR in {
+        return isinstance(self.location, GopherURI) and ItemType.ERROR in {
             item.type for item in GopherMap(self.content).items
         }
 

--- a/src/rogallo/document.py
+++ b/src/rogallo/document.py
@@ -81,7 +81,9 @@ class Document:
     @cached_property
     def is_gopher_error(self) -> bool:
         """`True` if the document is a Gopher error document, `False` otherwise."""
-        return ItemType.ERROR in {item.type for item in GopherMap(self.content).items}
+        return self.is_gophermap and ItemType.ERROR in {
+            item.type for item in GopherMap(self.content).items
+        }
 
     @property
     def is_renderable_as_gemtext(self) -> bool:

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -442,7 +442,10 @@ class Main(EnhancedScreen[None]):
         ):
             return bool(self._viewer.document)
         if action == ToggleView.action_name():
-            return bool(self._viewer.document) and self._viewer.document.is_source
+            return (
+                bool(self._viewer.document)
+                and self._viewer.document.is_renderable_as_gemtext
+            )
         if action == GoHome.action_name():
             return bool(load_configuration().home_page.strip())
         if action == AddLocationToBookmarks.action_name():
@@ -1261,7 +1264,7 @@ class Main(EnhancedScreen[None]):
 
     def action_toggle_view_command(self) -> None:
         """Toggle the view between rendered and source."""
-        if self._viewer.document.is_source:
+        if self._viewer.document.is_renderable_as_gemtext:
             self._viewer.view_source = not self._viewer.view_source
 
     def action_go_home_command(self) -> None:

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -195,6 +195,34 @@ class Viewer(Vertical, can_focus=False):
             )
         ]
 
+    def _build_content(self) -> list[Widget]:
+        """Build the content for the viewer.
+
+        Returns:
+            The content for the viewer based on the current document.
+        """
+        if self.document.is_renderable_as_gemtext:
+            if self.view_source:
+                return [
+                    Static(
+                        self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}")
+                    )
+                ]
+            return [
+                get_block_widget(line)
+                for line in self._consolidate(
+                    Gemtext(
+                        self.document.content
+                        if self.document.is_gemtext
+                        else "\n".join(to_gemtext(self.document.content)),
+                        with_spartan_support=isinstance(
+                            self.document.location, SpartanURI
+                        ),
+                    ).content
+                )
+            ]
+        return self._best_presentation_for(self.document)
+
     async def _watch_document(
         self, old_document: Document, new_document: Document
     ) -> None:
@@ -211,33 +239,9 @@ class Viewer(Vertical, can_focus=False):
         self._title.location = self.document.location
         self._status.mime_type = self.document.mime_type or ""
         self._jump_map = {}
-        content: list[Widget]
-        if self.document.is_renderable_as_gemtext:
-            if self.view_source:
-                content = [
-                    Static(
-                        self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}")
-                    )
-                ]
-            else:
-                content = [
-                    get_block_widget(line)
-                    for line in self._consolidate(
-                        Gemtext(
-                            self.document.content
-                            if self.document.is_gemtext
-                            else "\n".join(to_gemtext(self.document.content)),
-                            with_spartan_support=isinstance(
-                                self.document.location, SpartanURI
-                            ),
-                        ).content
-                    )
-                ]
-        else:
-            content = self._best_presentation_for(self.document)
         with self.app.batch_update():
             await self._view.remove_children()
-            await self._view.mount_all(content)
+            await self._view.mount_all(self._build_content())
             if (
                 self.document.is_gemtext or self.document.is_gophermap
             ) and not self.view_source:

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -14,6 +14,10 @@ from port70 import GopherURI
 from port79 import FingerURI
 
 ##############################################################################
+# Rich imports.
+from rich.text import Text
+
+##############################################################################
 # Sybaritic imports.
 from sybaritic import SpartanURI
 
@@ -178,12 +182,19 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             The best presentation for the document.
         """
+        # If it looks like the document has ANSI escape sequences in it,
+        # then we just dump it out as-is. There's no point in trying to
+        # highlight it.
         return [
             Static(
-                highlight(document.content, language=language, theme=HighlightTheme)
-                if not self.view_source
-                and (language := language_from_document(document))
-                else self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}"),
+                Text.from_ansi(document.content)
+                if "\x1b[" in document.content
+                else (
+                    highlight(document.content, language=language, theme=HighlightTheme)
+                    if not self.view_source
+                    and (language := language_from_document(document))
+                    else self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}")
+                ),
                 markup=False,
             )
         ]

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -188,7 +188,7 @@ class Viewer(Vertical, can_focus=False):
         return [
             Static(
                 Text.from_ansi(document.content)
-                if "\x1b[" in document.content
+                if "\x1b[" in document.content and not self.view_source
                 else (
                     highlight(document.content, language=language, theme=HighlightTheme)
                     if not self.view_source
@@ -219,12 +219,7 @@ class Viewer(Vertical, can_focus=False):
             self._jump_map = {}
             await self._view.mount_all(
                 self._best_presentation_for(self.document)
-                if not (
-                    self.document.is_gemtext
-                    or self.document.is_gophermap
-                    or self.document.is_gopher_error
-                )
-                or self.view_source
+                if not self.document.is_renderable_as_gemtext or self.view_source
                 else [
                     get_block_widget(line)
                     for line in self._consolidate(

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -182,18 +182,14 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             The best presentation for the document.
         """
-        # If it looks like the document has ANSI escape sequences in it,
-        # then we just dump it out as-is. There's no point in trying to
-        # highlight it.
         return [
             Static(
                 Text.from_ansi(document.content)
-                if "\x1b[" in document.content and not self.view_source
-                else (
-                    highlight(document.content, language=language, theme=HighlightTheme)
-                    if not self.view_source
-                    and (language := language_from_document(document))
-                    else self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}")
+                if "\x1b[" in document.content
+                else highlight(
+                    document.content,
+                    language=language_from_document(document),
+                    theme=HighlightTheme,
                 ),
                 markup=False,
             )
@@ -214,13 +210,17 @@ class Viewer(Vertical, can_focus=False):
         self._title.needed_certificate = self.document.needed_certificate
         self._title.location = self.document.location
         self._status.mime_type = self.document.mime_type or ""
-        with self.app.batch_update():
-            await self._view.remove_children()
-            self._jump_map = {}
-            await self._view.mount_all(
-                self._best_presentation_for(self.document)
-                if not self.document.is_renderable_as_gemtext or self.view_source
-                else [
+        self._jump_map = {}
+        content: list[Widget]
+        if self.document.is_renderable_as_gemtext:
+            if self.view_source:
+                content = [
+                    Static(
+                        self.document.content.replace(chr(27), "\N{SYMBOL FOR ESCAPE}")
+                    )
+                ]
+            else:
+                content = [
                     get_block_widget(line)
                     for line in self._consolidate(
                         Gemtext(
@@ -233,7 +233,11 @@ class Viewer(Vertical, can_focus=False):
                         ).content
                     )
                 ]
-            )
+        else:
+            content = self._best_presentation_for(self.document)
+        with self.app.batch_update():
+            await self._view.remove_children()
+            await self._view.mount_all(content)
             if (
                 self.document.is_gemtext or self.document.is_gophermap
             ) and not self.view_source:


### PR DESCRIPTION
This ignores any ANSI-related settings, on purpose (at least for now). The idea here being that if someone views a text file that has ANSI sequences within it, they want to see them.

Also fixes some text files accidentally being seen as Gopher error responses.

Also, in passing, cleans up the content rendering code a little. There were clever one-liners that were getting a little too clever. This PR breaks them down just a smidge.

Closes #299.
Closes #301.