### PR TITLE
Improve the navigation and display of local Gemtext files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@
 
 - Added simple encoding fallback so that ISO-8859-1 text files can be
   downloaded. ([#304](https://github.com/davep/rogallo/pull/304))
+- Fixed the icon shown for Gemtext links to other Gemtext files that are
+  linked to with a `file:` URI.
+  ([#310](https://github.com/davep/rogallo/pull/310))
 
 ## v1.6.2
 

--- a/src/rogallo/preflight.py
+++ b/src/rogallo/preflight.py
@@ -165,7 +165,6 @@ def path_from_uri(uri: str) -> Path:
     Raises:
         ValueError: If the URI can't be turned into a [`Path`][pathlib.Path].
     """
-
     if (parsed := urlparse(uri)).scheme.lower() == "file":
         return Path(parsed.path).resolve()
     elif not parsed.scheme and not parsed.netloc:
@@ -174,14 +173,18 @@ def path_from_uri(uri: str) -> Path:
 
 
 ##############################################################################
-def is_likely_local_file(uri: str) -> bool:
-    """Determine if a URI is likely a local file.
+def is_local_file(uri: str) -> bool:
+    """Determine if a URI is a local file.
 
     Args:
         uri: The URI to check.
 
     Returns:
-        `True` if the URI is likely a local file, `False` otherwise.
+        `True` if the URI is likely a file, `False` otherwise.
+
+    Notes:
+        The URI is considered to be a local file if it can be turned into a
+        [`Path`][pathlib.Path] and that path is a file that exists.
     """
     try:
         candidate = path_from_uri(uri)
@@ -191,8 +194,8 @@ def is_likely_local_file(uri: str) -> bool:
 
 
 ##############################################################################
-def is_likely_local_file_of_type(uri: str, mime_type: str) -> bool:
-    """Determine if a URI is likely a local file of a given type.
+def is_local_file_of_type(uri: str, mime_type: str) -> bool:
+    """Determine if a URI is a local file of a given MIME type.
 
     Args:
         uri: The URI to check.
@@ -200,8 +203,13 @@ def is_likely_local_file_of_type(uri: str, mime_type: str) -> bool:
 
     Returns:
         `True` if the URI is likely a local text file, `False` otherwise.
+
+    Notes:
+        The URI is only considered to be a local file if it can be turned
+        into a [`Path`][pathlib.Path] and that path is a file that exists,
+        and the MIME type of that file starts with the given `mime_type`.
     """
-    if not is_likely_local_file(uri):
+    if not is_local_file(uri):
         return False
     try:
         guessed_mime_type, _ = mimetypes.guess_type(path_from_uri(uri))
@@ -211,29 +219,39 @@ def is_likely_local_file_of_type(uri: str, mime_type: str) -> bool:
 
 
 ##############################################################################
-def is_likely_local_text_file(uri: str) -> bool:
-    """Determine if a URI is likely a local text file.
+def is_local_text_file(uri: str) -> bool:
+    """Determine if a URI is local text file.
 
     Args:
         uri: The URI to check.
 
     Returns:
-        `True` if the URI is likely a local text file, `False` otherwise.
+        `True` if the URI is a local text file, `False` otherwise.
+
+    Notes:
+        The URI is considered to be a local text file if it can be turned
+        into a [`Path`][pathlib.Path] and that path is a file that exists,
+        and the MIME type of that file starts with "text/".
     """
-    return is_likely_local_file_of_type(uri, "text/")
+    return is_local_file_of_type(uri, "text/")
 
 
 ##############################################################################
-def is_likely_local_gemtext_file(uri: str) -> bool:
-    """Determine if a URI is likely a local Gemtext file.
+def is_local_gemtext_file(uri: str) -> bool:
+    """Determine if a URI is a local Gemtext file.
 
     Args:
         uri: The URI to check.
 
     Returns:
-        `True` if the URI is likely a local Gemtext file, `False` otherwise.
+        `True` if the URI is a local Gemtext file, `False` otherwise.
+
+    Notes:
+        The URI is considered to be a local Gemtext file if it can be turned
+        into a [`Path`][pathlib.Path] and that path is a file that exists
+        and the MIME type comes back as the Gemini MIME type.
     """
-    return is_likely_local_file_of_type(uri, GEMINI_MIME_TYPE)
+    return is_local_file_of_type(uri, GEMINI_MIME_TYPE)
 
 
 ##############################################################################

--- a/src/rogallo/preflight.py
+++ b/src/rogallo/preflight.py
@@ -191,6 +191,26 @@ def is_likely_local_file(uri: str) -> bool:
 
 
 ##############################################################################
+def is_likely_local_file_of_type(uri: str, mime_type: str) -> bool:
+    """Determine if a URI is likely a local file of a given type.
+
+    Args:
+        uri: The URI to check.
+        mime_type: The MIME type to check for.
+
+    Returns:
+        `True` if the URI is likely a local text file, `False` otherwise.
+    """
+    if not is_likely_local_file(uri):
+        return False
+    try:
+        guessed_mime_type, _ = mimetypes.guess_type(path_from_uri(uri))
+    except ValueError:
+        return False
+    return guessed_mime_type is not None and guessed_mime_type.startswith(mime_type)
+
+
+##############################################################################
 def is_likely_local_text_file(uri: str) -> bool:
     """Determine if a URI is likely a local text file.
 
@@ -200,13 +220,20 @@ def is_likely_local_text_file(uri: str) -> bool:
     Returns:
         `True` if the URI is likely a local text file, `False` otherwise.
     """
-    if not is_likely_local_file(uri):
-        return False
-    try:
-        mime_type, _ = mimetypes.guess_type(path_from_uri(uri))
-    except ValueError:
-        return False
-    return mime_type is not None and mime_type.startswith("text/")
+    return is_likely_local_file_of_type(uri, "text/")
+
+
+##############################################################################
+def is_likely_local_gemtext_file(uri: str) -> bool:
+    """Determine if a URI is likely a local Gemtext file.
+
+    Args:
+        uri: The URI to check.
+
+    Returns:
+        `True` if the URI is likely a local Gemtext file, `False` otherwise.
+    """
+    return is_likely_local_file_of_type(uri, GEMINI_MIME_TYPE)
 
 
 ##############################################################################

--- a/src/rogallo/screens/main.py
+++ b/src/rogallo/screens/main.py
@@ -143,8 +143,8 @@ from ..messages import (
 )
 from ..mime_checks import is_displayable_mime_type
 from ..preflight import (
-    is_likely_local_text_file,
     is_likely_schemeless_capsule,
+    is_local_text_file,
     path_from_uri,
 )
 from ..providers import BookmarkSearchCommands, HistorySearchCommands, MainCommands
@@ -937,7 +937,7 @@ class Main(EnhancedScreen[None]):
                 pass
 
         # Perhaps it's a local text file?
-        if is_likely_local_text_file(message.uri):
+        if is_local_text_file(message.uri):
             self.post_message(OpenLocation(path_from_uri(message.uri)))
             return
 

--- a/src/rogallo/widgets/command_line/open_file.py
+++ b/src/rogallo/widgets/command_line/open_file.py
@@ -7,7 +7,7 @@ from textual.widget import Widget
 ##############################################################################
 # Local imports.
 from ...messages import OpenLocation
-from ...preflight import is_likely_local_text_file, path_from_uri
+from ...preflight import is_local_text_file, path_from_uri
 from .base_command import InputCommand
 
 
@@ -28,7 +28,7 @@ class OpenFileCommand(InputCommand):
         Returns:
             `True` if the command was handled; `False` if not.
         """
-        if is_likely_local_text_file(text):
+        if is_local_text_file(text):
             for_widget.post_message(OpenLocation(path_from_uri(text)))
             return True
         return False

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -43,7 +43,7 @@ from ....preflight import (
     is_finger_uri,
     is_gopher_uri,
     is_likely_capsule,
-    is_likely_local_gemtext_file,
+    is_local_gemtext_file,
     is_spartan_uri,
 )
 from ....types import RogalloLocation, SpartanURINeedingData
@@ -149,7 +149,7 @@ class GemtextLink(Horizontal, can_focus=True):
             (is_finger_uri, "fingerspace_link_icon"),
             (is_gopher_uri, "gopherspace_link_icon"),
             (is_spartan_uri, "spartanspace_link_icon"),
-            (is_likely_local_gemtext_file, "geminispace_link_icon"),
+            (is_local_gemtext_file, "geminispace_link_icon"),
         ):
             if checker(self.normalised_uri):
                 return icon(icon_name)

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -43,6 +43,7 @@ from ....preflight import (
     is_finger_uri,
     is_gopher_uri,
     is_likely_capsule,
+    is_likely_local_gemtext_file,
     is_spartan_uri,
 )
 from ....types import RogalloLocation, SpartanURINeedingData
@@ -148,6 +149,7 @@ class GemtextLink(Horizontal, can_focus=True):
             (is_finger_uri, "fingerspace_link_icon"),
             (is_gopher_uri, "gopherspace_link_icon"),
             (is_spartan_uri, "spartanspace_link_icon"),
+            (is_likely_local_gemtext_file, "geminispace_link_icon"),
         ):
             if checker(self.normalised_uri):
                 return icon(icon_name)


### PR DESCRIPTION
The main change in this PR is that, if the user is navigating a filesystem-based file, and a URI points to a directory rather than an explicit file (so in a normal online capsule, you'd expect to automatically land on an `index.gmi` file), Rogallo will look for an index file in that directory and transform the navigation to one that's navigating to that file.

Fixes #305.