### PR TITLE
Use richer widgets where available/sensible

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Rogallo ChangeLog
 
+## Unreleased
+
+**Released: 2026-08-10**
+
+- Viewing `text/markdown` or `text/x-markdown` documents now uses full
+  Markdown presentation in the viewer.
+  ([#320](https://github.com/davep/rogallo/pull/320))
+
 ## v1.7.0
 
 **Released: 2026-08-10**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,12 @@
 - Viewing `text/markdown` or `text/x-markdown` documents now uses full
   Markdown presentation in the viewer.
   ([#320](https://github.com/davep/rogallo/pull/320))
+- Viewing `text/html` documents now converts the HTML to Gemtext and
+  displays it using the Gemtext view.
+  ([#320](https://github.com/davep/rogallo/pull/320))
+- The `ToggleView` command now also toggles the Markdown and HTML views
+  between their richer presentations and their raw source view.
+  ([#320](https://github.com/davep/rogallo/pull/320))
 
 ## v1.7.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "bagofstuff>=1.2.1",
     "gemtext>=1.1.0",
     "gophermap>=0.2.0",
+    "html2gemtext>=0.1.0",
     "port70>=0.1.2",
     "port79>=1.0.0",
     "pyperclip>=1.11.0",

--- a/src/rogallo/__main__.py
+++ b/src/rogallo/__main__.py
@@ -139,6 +139,7 @@ def show_dignoastics() -> None:
     from cryptography import __version__ as cryptography_version
     from gemtext import __version__ as gemtext_version
     from gophermap import __version__ as gophermap_version
+    from html2gemtext import __version__ as html2gemtext_version
     from port70 import __version__ as port70_version
     from port79 import __version__ as port79_version
     from sybaritic import __version__ as sybaritic_version
@@ -152,6 +153,7 @@ def show_dignoastics() -> None:
     print(f"cryptography: {cryptography_version}")
     print(f"gemtext: {gemtext_version}")
     print(f"gophermap: {gophermap_version}")
+    print(f"html2gemtext: {html2gemtext_version}")
     print(f"port70: {port70_version}")
     print(f"port79: {port79_version}")
     print(f"rogallo: {__version__}")

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -442,10 +442,7 @@ class Main(EnhancedScreen[None]):
         ):
             return bool(self._viewer.document)
         if action == ToggleView.action_name():
-            return (
-                bool(self._viewer.document)
-                and self._viewer.document.is_renderable_as_gemtext
-            )
+            return bool(self._viewer.document) and self._viewer.can_view_source
         if action == GoHome.action_name():
             return bool(load_configuration().home_page.strip())
         if action == AddLocationToBookmarks.action_name():
@@ -894,7 +891,7 @@ class Main(EnhancedScreen[None]):
 
     def action_toggle_view_command(self) -> None:
         """Toggle the view between rendered and source."""
-        if self._viewer.document.is_renderable_as_gemtext:
+        if self._viewer.can_view_source:
             self._viewer.view_source = not self._viewer.view_source
 
     def action_go_home_command(self) -> None:

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -50,6 +50,7 @@ from wasat import GeminiURI
 # Local imports.
 from ...data import LocationHistory, load_configuration
 from ...document import Document
+from ...types import GEMINI_MIME_TYPE
 from .document_view import DocumentView
 from .gemtext import GemtextContent, GemtextLink, get_block_widget
 from .gopher import to_gemtext
@@ -177,6 +178,20 @@ class Viewer(Vertical, can_focus=False):
         if buffer:
             yield Paragraph("\n".join(buffer))
 
+    @property
+    def can_view_source(self) -> bool:
+        """Whether the viewer can view the source of the document.
+
+        Returns:
+            Whether the viewer can view the source of the document.
+        """
+        return self.document.mime_type_sans_parameters in (
+            GEMINI_MIME_TYPE,
+            "text/markdown",
+            "text/x-markdown",
+            "text/html",
+        )
+
     def _gemtext_widgets(
         self, content: str, with_spartan_support: bool = False
     ) -> list[Widget]:
@@ -208,10 +223,14 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             The best presentation for the document.
         """
-        if document.mime_type_sans_parameters in ("text/markdown", "text/x-markdown"):
-            return [Markdown(document.content)]
-        if document.mime_type_sans_parameters == "text/html":
-            return self._gemtext_widgets(html_to_gemtext(document.content))
+        if not self.view_source:
+            if document.mime_type_sans_parameters in (
+                "text/markdown",
+                "text/x-markdown",
+            ):
+                return [Markdown(document.content)]
+            if document.mime_type_sans_parameters == "text/html":
+                return self._gemtext_widgets(html_to_gemtext(document.content))
         return [
             Static(
                 Text.from_ansi(document.content)

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -9,6 +9,10 @@ from collections.abc import Iterator
 from gemtext import Gemtext, Line, Paragraph
 
 ##############################################################################
+# html2gemtext imports.
+from html2gemtext import html_to_gemtext
+
+##############################################################################
 # Port79 imports.
 from port70 import GopherURI
 from port79 import FingerURI
@@ -173,6 +177,28 @@ class Viewer(Vertical, can_focus=False):
         if buffer:
             yield Paragraph("\n".join(buffer))
 
+    def _gemtext_widgets(
+        self, content: str, with_spartan_support: bool = False
+    ) -> list[Widget]:
+        """Build a list of widgets to display the Gemtext content.
+
+        Args:
+            content: The content to convert.
+            with_spartan_support: Whether to support Spartan links.
+
+        Returns:
+            The widgets for the Gemtext content.
+        """
+        return [
+            get_block_widget(line)
+            for line in self._consolidate(
+                Gemtext(
+                    content,
+                    with_spartan_support=with_spartan_support,
+                ).content
+            )
+        ]
+
     def _best_presentation_for(self, document: Document) -> list[Widget]:
         """Get the best presentation for the document.
 
@@ -182,11 +208,12 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             The best presentation for the document.
         """
-        widget: Widget
         if document.mime_type_sans_parameters in ("text/markdown", "text/x-markdown"):
-            widget = Markdown(document.content)
-        else:
-            widget = Static(
+            return [Markdown(document.content)]
+        if document.mime_type_sans_parameters == "text/html":
+            return self._gemtext_widgets(html_to_gemtext(document.content))
+        return [
+            Static(
                 Text.from_ansi(document.content)
                 if "\x1b[" in document.content
                 else highlight(
@@ -196,7 +223,7 @@ class Viewer(Vertical, can_focus=False):
                 ),
                 markup=False,
             )
-        return [widget]
+        ]
 
     def _build_content(self) -> list[Widget]:
         """Build the content for the viewer.
@@ -212,19 +239,12 @@ class Viewer(Vertical, can_focus=False):
                         markup=False,
                     )
                 ]
-            return [
-                get_block_widget(line)
-                for line in self._consolidate(
-                    Gemtext(
-                        self.document.content
-                        if self.document.is_gemtext
-                        else "\n".join(to_gemtext(self.document.content)),
-                        with_spartan_support=isinstance(
-                            self.document.location, SpartanURI
-                        ),
-                    ).content
-                )
-            ]
+            return self._gemtext_widgets(
+                self.document.content
+                if self.document.is_gemtext
+                else "\n".join(to_gemtext(self.document.content)),
+                with_spartan_support=isinstance(self.document.location, SpartanURI),
+            )
         return self._best_presentation_for(self.document)
 
     async def _watch_document(

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -183,7 +183,7 @@ class Viewer(Vertical, can_focus=False):
             The best presentation for the document.
         """
         widget: Widget
-        if document.mime_type in ("text/markdown", "text/x-markdown"):
+        if document.mime_type_sans_parameters in ("text/markdown", "text/x-markdown"):
             widget = Markdown(document.content)
         else:
             widget = Static(

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -32,7 +32,7 @@ from textual.highlight import HighlightTheme, highlight
 from textual.reactive import var
 from textual.timer import Timer
 from textual.widget import Widget
-from textual.widgets import Static
+from textual.widgets import Markdown, Static
 
 ##############################################################################
 # Textual enhanced imports.
@@ -182,8 +182,11 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             The best presentation for the document.
         """
-        return [
-            Static(
+        widget: Widget
+        if document.mime_type in ("text/markdown", "text/x-markdown"):
+            widget = Markdown(document.content)
+        else:
+            widget = Static(
                 Text.from_ansi(document.content)
                 if "\x1b[" in document.content
                 else highlight(
@@ -193,7 +196,7 @@ class Viewer(Vertical, can_focus=False):
                 ),
                 markup=False,
             )
-        ]
+        return [widget]
 
     def _build_content(self) -> list[Widget]:
         """Build the content for the viewer.

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -178,6 +178,16 @@ class Viewer(Vertical, can_focus=False):
         if buffer:
             yield Paragraph("\n".join(buffer))
 
+    _WITH_SOURCE_MIME_TYPES = frozenset(
+        {
+            GEMINI_MIME_TYPE,
+            "text/markdown",
+            "text/x-markdown",
+            "text/html",
+        }
+    )
+    """The MIME types that can be viewed as source."""
+
     @property
     def can_view_source(self) -> bool:
         """Whether the viewer can view the source of the document.
@@ -185,12 +195,7 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             Whether the viewer can view the source of the document.
         """
-        return self.document.mime_type_sans_parameters in (
-            GEMINI_MIME_TYPE,
-            "text/markdown",
-            "text/x-markdown",
-            "text/html",
-        )
+        return self.document.mime_type_sans_parameters in self._WITH_SOURCE_MIME_TYPES
 
     def _gemtext_widgets(
         self, content: str, with_spartan_support: bool = False
@@ -214,6 +219,14 @@ class Viewer(Vertical, can_focus=False):
             )
         ]
 
+    _MARKDOWN_MIME_TYPES = frozenset(
+        {
+            "text/markdown",
+            "text/x-markdown",
+        }
+    )
+    """The MIME types that can be viewed as Markdown."""
+
     def _best_presentation_for(self, document: Document) -> list[Widget]:
         """Get the best presentation for the document.
 
@@ -224,10 +237,7 @@ class Viewer(Vertical, can_focus=False):
             The best presentation for the document.
         """
         if not self.view_source:
-            if document.mime_type_sans_parameters in (
-                "text/markdown",
-                "text/x-markdown",
-            ):
+            if document.mime_type_sans_parameters in self._MARKDOWN_MIME_TYPES:
                 return [Markdown(document.content)]
             if document.mime_type_sans_parameters == "text/html":
                 return self._gemtext_widgets(html_to_gemtext(document.content))

--- a/uv.lock
+++ b/uv.lock
@@ -726,6 +726,15 @@ wheels = [
 ]
 
 [[package]]
+name = "html2gemtext"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/1d/7e842b0402c03eeb1b1c39bfd0dfe6d80feaeaf6f8689d10feceb6f9d74e/html2gemtext-0.1.0.tar.gz", hash = "sha256:84360f629c25c797d96921a2662a83777f09bf93e7f8cd876d37358567c66ab2", size = 5165, upload-time = "2026-08-11T18:38:30.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/c8/90e64e7bcd5fe382981a3dbe795f03909520c04cb2ccbf1da2046b3343e2/html2gemtext-0.1.0-py3-none-any.whl", hash = "sha256:f13e3c9ff41edcdc8e2fa058deb5dbbe788b37eefbe1f27002f3add28c74bd72", size = 6621, upload-time = "2026-08-11T18:38:29.265Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1652,6 +1661,7 @@ dependencies = [
     { name = "bagofstuff" },
     { name = "gemtext" },
     { name = "gophermap" },
+    { name = "html2gemtext" },
     { name = "port70" },
     { name = "port79" },
     { name = "pyperclip" },
@@ -1686,6 +1696,7 @@ requires-dist = [
     { name = "bagofstuff", specifier = ">=1.2.1" },
     { name = "gemtext", specifier = ">=1.1.0" },
     { name = "gophermap", specifier = ">=0.2.0" },
+    { name = "html2gemtext", specifier = ">=0.1.0" },
     { name = "port70", specifier = ">=0.1.2" },
     { name = "port79", specifier = ">=1.0.0" },
     { name = "pyperclip", specifier = ">=1.11.0" },


### PR DESCRIPTION
Added:

- If viewing a `text/markdown` or `text/x-markdown` document, use the builtin Markdown widget.
- If viewing a `text/html` document, use `html2gemtext` to view the document as rendered gemtext.
- The `ToggleView` command now also toggles the above between the rendered and source views.
