### PR TITLE
Add the ability to hide specific pre blocks

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,9 @@
   ([#326](https://github.com/davep/rogallo/pull/326))
 - Fixed a false positive when detecting an error response from a Gopher
   server. ([#328](https://github.com/davep/rogallo/pull/328))
+- Added `hide_preformatted` to the configuration file. Allows you to hide
+  specific pre-formatted blocks at specific locations.
+  ([#329](https://github.com/davep/rogallo/pull/329))
 
 ## v1.7.0
 

--- a/docs/source/viewer.md
+++ b/docs/source/viewer.md
@@ -51,4 +51,39 @@ To jump to that link, simply type its number.
 ```{.textual path="docs/screenshots/stripes_screenshot.py" title="A highlighted link after typing its number" lines=30 columns=70 press="5"}
 ```
 
+## Configuration
+
+### Filtering out pre-formatted text
+
+Because pre-formatted text can be used to generate site logos and similar,
+this can sometimes mean that you're faced with viewing the same ASCII art
+over and over again, that uses up vertical space, and means it takes longer
+to get to the content of a site. With this in mind Rogallo has a facility
+for hiding specific pre-formatted text. It is based on the idea that such
+pre-formatted blocks will have alt-text, and that we will normally only want
+to do it for a specific URI. As an example: suppose I wanted to hide *my*
+avatar image on [Station](gemini://station.martinrue.com/), and also the
+site logo to save some space, I can set the following in the configuration
+file:
+
+```json
+"hide_preformatted": [
+    [
+        "gemini://station.martinrue.com/",
+        "Station logo"
+    ],
+    [
+        "gemini://station.martinrue.com/davep",
+        "User image"
+    ]
+]
+```
+
+As you can see, the filters are defined as a list of lists. The first value
+in each is the URI to match. This will match *that location and all below
+it*. So in the above `gemini://station.martinrue.com/` would match that
+location, and also `gemini://station.martinrue.com/davep` and
+`gemini://station.martinrue.com/example-user` and so on. The second value is
+the alt-text for the pre-formatted text.
+
 [//]: # (viewer.md ends here)

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -135,6 +135,9 @@ class Configuration:
     blend_pre_formatted_with_background: list[str] = field(default_factory=lambda: [""])
     """List of types of pre-formatted text to blend with the background."""
 
+    hide_preformatted: list[tuple[str, str]] = field(default_factory=list)
+    """List of (URI-prefix, alt-text) tuples of pre-formatted text to hide."""
+
     gopher_show_type_badges: bool = True
     """Whether to show badges for Gopher item types."""
 

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -3,10 +3,11 @@
 ##############################################################################
 # Python imports.
 from collections.abc import Iterator
+from functools import cached_property
 
 ##############################################################################
 # Gemtext imports.
-from gemtext import Gemtext, Line, Paragraph
+from gemtext import Gemtext, Line, Paragraph, PreFormatted
 
 ##############################################################################
 # html2gemtext imports.
@@ -197,6 +198,23 @@ class Viewer(Vertical, can_focus=False):
         """
         return self.document.mime_type_sans_parameters in self._WITH_SOURCE_MIME_TYPES
 
+    @cached_property
+    def _hidden_pre_alt_text(self) -> set[tuple[str, str]]:
+        """Get the set of preformatted types that should be hidden.
+
+        Returns:
+            The set of preformatted types that should be hidden.
+        """
+        cleaned = (
+            entry
+            for entry in load_configuration().hide_preformatted
+            if len(entry) == 2 and all(isinstance(element, str) for element in entry)
+        )
+        return set(
+            (uri_prefix.casefold(), alt_text.casefold())
+            for uri_prefix, alt_text in cleaned
+        )
+
     def _gemtext_widgets(
         self, content: str, with_spartan_support: bool = False
     ) -> list[Widget]:
@@ -209,6 +227,15 @@ class Viewer(Vertical, can_focus=False):
         Returns:
             The widgets for the Gemtext content.
         """
+        current_location = (
+            str(self.document.location).casefold() if self.document.location else ""
+        )
+        # Get the set of alt_texts to ignore based on the current location.
+        alt_text_to_ignore = {
+            alt_text
+            for uri_prefix, alt_text in self._hidden_pre_alt_text
+            if self.document.location and current_location.startswith(uri_prefix)
+        }
         return [
             get_block_widget(line)
             for line in self._consolidate(
@@ -216,6 +243,12 @@ class Viewer(Vertical, can_focus=False):
                     content,
                     with_spartan_support=with_spartan_support,
                 ).content
+            )
+            # Filter out any preformatted blocks that have an alt text we
+            # should ignore.
+            if not (
+                isinstance(line, PreFormatted)
+                and line.alt_text.casefold() in alt_text_to_ignore
             )
         ]
 


### PR DESCRIPTION
The idea is to have a method via which you can hide a specific preformatted block, or a whole set of them. For example, if I wanted to hide my own view of my user image on Station, and also recover some vertical space from the site logo when visiting Station, I might configure like this:

```json
    "hide_preformatted": [
        [
            "gemini://station.martinrue.com/",
            "Station logo"
        ],
        [
            "gemini://station.martinrue.com/davep",
            "User image"
        ]
    ],
```

Inspired by gemini://station.martinrue.com/freezr/54d38c82c214477eba340638ce787e2f

TODO:

- [x] Add documentation