### PR TITLE
Add a dev/debug-oriented ANSI screenshot facility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Rogallo ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Added a development-oriented tool for taking ANSI "screenshots" of
+  Rogallo. ([#336](https://github.com/davep/rogallo/pull/336))
+
 ## v1.8.0
 
 **Released: 2026-08-13**

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ mkdocs   := $(smolexec) mkdocs
 # Local "interactive testing" of the code.
 .PHONY: run
 run:				# Run the code in a testing context
-	$(run) $(app)
+	ROGALLO_SCREENSHOTS=1 $(run) $(app)
 
 .PHONY: serve
 serve:				# Run in server mode for use in the browser

--- a/src/rogallo/_screenshot.py
+++ b/src/rogallo/_screenshot.py
@@ -4,6 +4,7 @@
 # Python imports.
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 ##############################################################################
 # Textual imports.
@@ -11,7 +12,7 @@ from textual.app import App
 
 
 ##############################################################################
-def _ansi_representation_of(app: App) -> Iterator[str]:
+def _ansi_representation_of(app: App[Any]) -> Iterator[str]:
     """Get the ANSI representation of the Textual app's screen.
 
     Args:
@@ -34,7 +35,7 @@ def _ansi_representation_of(app: App) -> Iterator[str]:
 
 
 ##############################################################################
-def save_ansi_screenshot(app: App, screenshot: Path | str) -> None:
+def save_ansi_screenshot(app: App[Any], screenshot: Path | str) -> None:
     """Save the ANSI representation of the Textual app's screen to a file.
 
     Args:

--- a/src/rogallo/_screenshot.py
+++ b/src/rogallo/_screenshot.py
@@ -1,0 +1,49 @@
+"""Utility function for taking an ANSI screenshot."""
+
+##############################################################################
+# Python imports.
+from collections.abc import Iterator
+from pathlib import Path
+
+##############################################################################
+# Textual imports.
+from textual.app import App
+
+
+##############################################################################
+def _ansi_representation_of(app: App) -> Iterator[str]:
+    """Get the ANSI representation of the Textual app's screen.
+
+    Args:
+        app: The Textual app to get the ANSI representation of.
+
+    Returns:
+        An iterator of strings representing the ANSI representation of the
+        app's screen.
+    """
+    for strip in app.screen._compositor.render_strips():
+        yield "".join(
+            segment.style.render(
+                segment.text,
+                color_system=app.console._color_system,
+            )
+            if segment.style
+            else segment.text
+            for segment in strip
+        )
+
+
+##############################################################################
+def save_ansi_screenshot(app: App, screenshot: Path | str) -> None:
+    """Save the ANSI representation of the Textual app's screen to a file.
+
+    Args:
+        app: The Textual app to save the ANSI representation of.
+        screenshot: The file path where the ANSI text output will be written.
+    """
+    Path(screenshot).expanduser().write_text(
+        "\n".join(_ansi_representation_of(app)) + "\n", encoding="utf-8"
+    )
+
+
+### _screenshot.py ends here

--- a/src/rogallo/rogallo.py
+++ b/src/rogallo/rogallo.py
@@ -3,10 +3,13 @@
 ##############################################################################
 # Python imports.
 from argparse import Namespace
+from os import getenv
+from typing import Final
 
 ##############################################################################
 # Textual imports.
 from textual.app import InvalidThemeError
+from textual.binding import Binding
 from textual.screen import Screen
 
 ##############################################################################
@@ -22,6 +25,10 @@ from .data import (
     update_configuration,
 )
 from .screens import Main
+
+##############################################################################
+ROGALLO_SCREENSHOTS: Final[bool] = bool(getenv("ROGALLO_SCREENSHOTS"))
+"""Should we enable the ANSI screenshot feature?"""
 
 
 ##############################################################################
@@ -53,6 +60,20 @@ class Rogallo(EnhancedApp[None]):
 
     COMMANDS = set()
 
+    BINDINGS = (
+        [
+            Binding(
+                "ctrl+shift+f12",
+                "ansi_screenshot",
+                "Take ANSI screenshot",
+                priority=True,
+                show=False,
+            ),
+        ]
+        if ROGALLO_SCREENSHOTS
+        else []
+    )
+
     def __init__(self, arguments: Namespace) -> None:
         """Initialise the application.
 
@@ -81,6 +102,15 @@ class Rogallo(EnhancedApp[None]):
 
     def get_default_screen(self) -> Screen[None]:
         return Main(self._arguments)
+
+    def action_ansi_screenshot(self) -> None:
+        """Take an ANSI screenshot of the application."""
+        if not ROGALLO_SCREENSHOTS:
+            return
+        from ._screenshot import save_ansi_screenshot
+
+        save_ansi_screenshot(self, screenshot := "~/rogallo-screenshot.ansi")
+        self.notify(screenshot, title="Saved")
 
 
 ### rogallo.py ends here


### PR DESCRIPTION
Not really aimed at the end user, and with a hard-coded location for the screenshot file. More of an experiment than anything.

If `ROGALLO_SCREENSHOTS` is in the environment and isn't empty then <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F12</kbd> will write a capture of the screen as ANSI escape sequences to `~/rogallo-screenshot.ansi`.