### PR TITLE
Add a mouse-oriented toolbar

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Rogallo ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Swapped the header bar out for an optional mouse-oriented toolbar of
+  command buttons. ([#357](https://github.com/davep/rogallo/pull/357))
+
 ## v1.10.0
 
 **Released: 2026-08-18**

--- a/docs/screenshots/no_toolbar_screenshot.py
+++ b/docs/screenshots/no_toolbar_screenshot.py
@@ -1,0 +1,10 @@
+"""Screenshot to show the toolbar removed."""
+
+from support.maker import make_app
+
+app = make_app(toolbar_visible=False)
+
+if __name__ == "__main__":
+    app.run()
+
+### no_toolbar_screenshot.py ends here

--- a/docs/source/toolbar.md
+++ b/docs/source/toolbar.md
@@ -1,0 +1,117 @@
+# The toolbar
+
+## Introduction
+
+While Rogallo is designed to be keyboard-friendly and, where possible,
+keyboard-first, it also has mouse support. If you are someone who tends to
+use the mouse more than the keyboard, you'll probably find yourself wanting
+quick and easy access to common commands, in a way that you can simply click
+on them.
+
+With this in mind, Rogallo has an optional mouse-oriented toolbar. This can
+be seen at the top of the screen.
+
+```{.textual path="docs/screenshots/main_screenshot.py" title="The toolbar" lines=40 columns=85}
+```
+
+## Toolbar content
+
+The content of the toolbar can be configured in the configuration file,
+using the `toolbar_contents` setting. The value is a list of [bindable
+commands](./configuration.md#bindable-commands), along with an optional text
+to show in the toolbar. By default the value is set to this:
+
+```json
+"toolbar_contents": [
+    [
+        "GoHome",
+        "\u2302"
+    ],
+    [
+        "Reload",
+        "\u21bb"
+    ],
+    [
+        "Backward",
+        "\u25c0\u25c0"
+    ],
+    [
+        "Forward",
+        "\u25b6\u25b6"
+    ],
+    [
+        "GoToParent",
+        "\u2191"
+    ],
+    [
+        "GoToRoot",
+        "\u21c8"
+    ],
+    [
+        "SearchHistory",
+        "\u25f7"
+    ],
+    [
+        "SearchBookmarks",
+        "\u2605"
+    ],
+    [
+        "ToggleView",
+        "\u21cb"
+    ]
+]
+```
+
+In each case it's a command name, along with the text to show in the toolbar
+(in these cases, icon-type values to help save space). To configure the
+content of the toolbar, edit the configuration file to add or remove
+commands.
+
+## Hiding the toolbar
+
+If you are someone who is keyboard-only and has no use for the toolbar, you
+can turn it off with this configuration file value:
+
+```json
+"toolbar_visible": true,
+```
+
+Set it to `false` to hide the toolbar.
+
+```{.textual path="docs/screenshots/no_toolbar_screenshot.py" title="Hidden toolbar" lines=40 columns=85}
+```
+
+## Turning off tooltips
+
+By default, the toolbar will show tooltips when you hover the mouse cursor
+over a button.
+
+```{.textual path="docs/screenshots/main_screenshot.py" title="Mouse hovering over the last toolbar button" lines=35 columns=90 hover="CommandButton:last-of-type"}
+```
+
+If you would prefer that these tooltips don't show, change this
+configuration file setting:
+
+```json
+"toolbar_tooltips": true
+```
+
+## Using the toolbar with the keyboard
+
+By default the toolbar can't be used via the keyboard; it is intended to be
+a mouse-oriented feature. All of the commands that you could add to the
+toolbar will already have keyboard bindings so the intention is that you
+learn and use them (or run the commands via the command palette).
+
+However, if you would prefer to be able to use the keyboard to navigate into
+the toolbar, this can be turned on by changing this configuration setting:
+
+```json
+"toolbar_can_get_focus": false,
+```
+
+Setting this to `true` means that all of the toolbar buttons will be capable
+of receiving focus and being navigable like all other UI elements that are
+capable of receiving focus.
+
+[//]: # (toolbar.md ends here)

--- a/docs/source/ui.md
+++ b/docs/source/ui.md
@@ -5,6 +5,7 @@ interface.
 
 - [The command line](./command-line.md)
 - [The sidebar](./sidebar.md)
+- [The toolbar](./toolbar.md)
 - [The viewer](./viewer.md)
 
 You may also wish to customise the look of Rogallo. This can be done by

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - ui.md
       - command-line.md
       - sidebar.md
+      - toolbar.md
       - viewer.md
       - custom-themes.md
   - "Configuration": configuration.md

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -185,6 +185,30 @@ class Configuration:
     convert_markdown_to_gemtext: bool = True
     """Whether to convert Markdown documents to Gemtext for display."""
 
+    toolbar_visible: bool = True
+    """Whether the toolbar is visible."""
+
+    toolbar_contents: list[str | list[str]] = field(
+        default_factory=lambda: [
+            ["GoHome", "⌂"],
+            ["Reload", "↻"],
+            ["Backward", "◀◀"],
+            ["Forward", "▶▶"],
+            ["GoToParent", "↑"],
+            ["GoToRoot", "⇈"],
+            ["SearchHistory", "◷"],
+            ["SearchBookmarks", "★"],
+            ["ToggleView", "⇋"],
+        ]
+    )
+    """The contents of the toolbar."""
+
+    toolbar_can_get_focus: bool = False
+    """Whether the toolbar can get focus."""
+
+    toolbar_tooltips: bool = True
+    """Whether the toolbar buttons have tooltips."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -345,6 +345,7 @@ class Main(EnhancedScreen[None]):
                 yield Toolbar(
                     buttons=load_configuration().toolbar_contents,
                     commands=Main.COMMAND_MESSAGES,
+                    version=__version__,
                     can_focus=load_configuration().toolbar_can_get_focus,
                     show_tooltips=load_configuration().toolbar_tooltips,
                 )

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -343,7 +343,8 @@ class Main(EnhancedScreen[None]):
         with VerticalGroup():
             if load_configuration().toolbar_visible:
                 yield Toolbar(
-                    commands=load_configuration().toolbar_contents,
+                    buttons=load_configuration().toolbar_contents,
+                    commands=Main.COMMAND_MESSAGES,
                     can_focus=load_configuration().toolbar_can_get_focus,
                     show_tooltips=load_configuration().toolbar_tooltips,
                 )

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -45,7 +45,7 @@ from textual.containers import HorizontalGroup, VerticalGroup
 from textual.getters import query_one
 from textual.reactive import var
 from textual.suggester import SuggestFromList
-from textual.widgets import Footer, Header, Label
+from textual.widgets import Footer, Label
 from textual.worker import get_current_worker
 
 ##############################################################################
@@ -130,7 +130,7 @@ from ...input_content import InputContent
 from ...messages import OpenFromFileSystem, OpenLocation, OpenURI
 from ...providers import BookmarkSearchCommands, HistorySearchCommands, MainCommands
 from ...types import GEMINI_EXTENSIONS, SpartanURINeedingData
-from ...widgets import BookmarksViewer, CommandLine, HistoryViewer, Viewer
+from ...widgets import BookmarksViewer, CommandLine, HistoryViewer, Toolbar, Viewer
 from ..about_page import AboutPage
 from ..confirm_unsupported import ConfirmUnsupportedURI
 from .filesystem import handle_filesystem_request
@@ -340,8 +340,13 @@ class Main(EnhancedScreen[None]):
 
     def compose(self) -> ComposeResult:
         """Compose the content of the main screen."""
-        yield Header()
         with VerticalGroup():
+            if load_configuration().toolbar_visible:
+                yield Toolbar(
+                    commands=load_configuration().toolbar_contents,
+                    can_focus=load_configuration().toolbar_can_get_focus,
+                    show_tooltips=load_configuration().toolbar_tooltips,
+                )
             with Workspace():
                 yield Viewer().data_bind(location_history=Main._location_history)
                 with VerticalGroup(id="history"):

--- a/src/rogallo/widgets/__init__.py
+++ b/src/rogallo/widgets/__init__.py
@@ -5,11 +5,12 @@
 from .bookmarks import BookmarksViewer
 from .command_line import CommandLine
 from .history import HistoryViewer
+from .toolbar import Toolbar
 from .viewer import Viewer
 
 ##############################################################################
 # Exports.
-__all__ = ["BookmarksViewer", "CommandLine", "HistoryViewer", "Viewer"]
+__all__ = ["BookmarksViewer", "CommandLine", "HistoryViewer", "Toolbar", "Viewer"]
 
 
 ### __init__.py ends here

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -1,6 +1,10 @@
 """Provides a toolbar widget that holds command buttons."""
 
 ##############################################################################
+# Python imports.
+from typing import Any
+
+##############################################################################
 # Textual imports.
 from textual import on
 from textual.app import ComposeResult
@@ -172,7 +176,7 @@ class Toolbar(Horizontal):
                 )
         yield Label(f"v{__version__}", id="version")
 
-    def _bindings_updated(self, screen: Screen) -> None:
+    def _bindings_updated(self, screen: Screen[Any]) -> None:
         """React to the bindings being updated on the screen.
 
         Args:

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -1,0 +1,194 @@
+"""Provides a toolbar widget that holds command buttons."""
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.events import Click
+from textual.screen import Screen
+from textual.widget import Widget
+from textual.widgets import Label
+
+##############################################################################
+# Textual enhanced imports.
+from textual_enhanced.commands import Command
+from textual_enhanced.commands.bindings import primary_key_for
+
+##############################################################################
+# Local imports.
+from .. import __version__, commands
+
+
+##############################################################################
+class CommandButton(Widget):
+    """A command button widget that can be clicked to execute a command."""
+
+    DEFAULT_CSS = """
+    CommandButton {
+        color: $text-muted;
+        background: $surface-lighten-2;
+        width: auto;
+        height: 1;
+        pointer: pointer;
+        padding: 0 1;
+        margin: 0 1;
+        &:first-of-type {
+            margin-left: 0;
+        }
+        &:focus {
+            color: $text;
+            background: $block-cursor-background;
+            text-style: bold;
+        }
+        &:hover {
+            color: $text;
+            background: $block-hover-background;
+            text-style: bold;
+        }
+        &:disabled {
+            text-opacity: 50%;
+            opacity: 50%;
+        }
+    }
+    """
+
+    BINDINGS = [("enter", "execute_command", "Execute command")]
+
+    def __init__(
+        self,
+        command: type[Command],
+        title: str | None,
+        can_focus: bool = False,
+        show_tooltip: bool = False,
+    ) -> None:
+        """Initialise the command button.
+
+        Args:
+            command: The command to execute when the button is clicked.
+            title: Optional title for the command.
+            can_focus: Whether the button can be focused.
+            show_tooltip: Whether to show a tooltip for the button.
+        """
+        super().__init__()
+        self._command = command
+        """The command that is executed by this button."""
+        self._title = title
+        """The title of the button."""
+        self._show_tooltip = show_tooltip
+        """Whether to show a tooltip for the button."""
+        self.can_focus = can_focus
+
+    def render(self) -> str:
+        """Render the button."""
+        return self._title or self._command().context_command
+
+    def on_mount(self) -> None:
+        """Configure the widget once mounted."""
+        if self._show_tooltip:
+            self.tooltip = f"{self._command().context_tooltip} [$accent]\\[{primary_key_for(self, self._command)}]"
+        self.refresh_enabled_state()
+
+    @on(Click)
+    async def action_execute_command(self) -> None:
+        """Execute the command."""
+        await self.screen.run_action(self._command.action_name())
+
+    def refresh_enabled_state(self) -> None:
+        """Refresh the enabled state of the button."""
+        self.disabled = not bool(
+            self.is_mounted
+            and self.screen.check_action(self._command.action_name(), ())
+        )
+
+
+##############################################################################
+class Toolbar(Horizontal):
+    """A toolbar widget that holds command buttons."""
+
+    DEFAULT_CSS = """
+    Toolbar {
+        height: 1;
+        background: $surface;
+        color: $foreground;
+        #version {
+            dock: right;
+            padding: 0 1;
+            color: $text-muted;
+        }
+        & > .error {
+            color: $error;
+            margin: 0 1;
+            padding: 0 1;
+        }
+    }
+    """
+
+    def __init__(
+        self,
+        commands: list[str | list[str]],
+        can_focus: bool = False,
+        show_tooltips: bool = True,
+    ):
+        """Initialise the toolbar.
+
+        Args:
+            commands: The commands to show in the toolbar.
+            can_focus: Whether the toolbar can be focused.
+            show_tooltips: Whether to show tooltips for the buttons in the toolbar.
+        """
+        super().__init__()
+        self._can_focus_buttons = can_focus
+        """Whether the buttons in the toolbar can be focused."""
+        self._show_button_tooltips = show_tooltips
+        """Whether to show tooltips for the buttons in the toolbar."""
+        self._commands = commands
+        """The commands to show in the toolbar."""
+
+    def compose(self) -> ComposeResult:
+        """Compose the toolbar."""
+        for toolbar_button in self._commands:
+            try:
+                command_name, title = (
+                    toolbar_button
+                    if isinstance(toolbar_button, list)
+                    else (toolbar_button, None)
+                )
+            except ValueError:
+                yield Label("Error", classes="error").with_tooltip(
+                    "Invalid command button configuration item"
+                )
+                continue
+            if command := getattr(commands, command_name, None):
+                yield CommandButton(
+                    command=command,
+                    title=title,
+                    can_focus=self._can_focus_buttons,
+                    show_tooltip=self._show_button_tooltips,
+                )
+            else:
+                yield Label(command_name, markup=False, classes="error").with_tooltip(
+                    f"{command_name} is an unknown command"
+                )
+        yield Label(f"v{__version__}", id="version")
+
+    def _bindings_updated(self, screen: Screen) -> None:
+        """React to the bindings being updated on the screen.
+
+        Args:
+            screen: The screen that has updated bindings.
+        """
+        if self.is_mounted and screen is self.screen:
+            for button in self.query(CommandButton):
+                button.refresh_enabled_state()
+
+    def on_mount(self) -> None:
+        """Configure the widget once mounted."""
+        self.screen.bindings_updated_signal.subscribe(self, self._bindings_updated)
+
+    def on_unmouunt(self) -> None:
+        """Clean up the widget when being unmounted."""
+        self.screen.bindings_updated_signal.unsubscribe(self)
+
+
+### toolbar.py ends here

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -109,7 +109,7 @@ class Toolbar(Horizontal):
     DEFAULT_CSS = """
     Toolbar {
         height: 1;
-        background: $surface;
+        background: $panel;
         color: $foreground;
         #version {
             dock: right;

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # Python imports.
-from typing import Any
+from typing import Any, Iterable
 
 ##############################################################################
 # Textual imports.
@@ -21,7 +21,7 @@ from textual_enhanced.commands.bindings import primary_key_for
 
 ##############################################################################
 # Local imports.
-from .. import __version__, commands
+from .. import __version__
 
 
 ##############################################################################
@@ -130,28 +130,32 @@ class Toolbar(Horizontal):
 
     def __init__(
         self,
-        commands: list[str | list[str]],
+        buttons: list[str | list[str]],
+        commands: Iterable[type[Command]],
         can_focus: bool = False,
         show_tooltips: bool = True,
     ):
         """Initialise the toolbar.
 
         Args:
-            commands: The commands to show in the toolbar.
+            buttons: The buttons to show in the toolbar.
+            commands: The commands available to the toolbar.
             can_focus: Whether the toolbar can be focused.
             show_tooltips: Whether to show tooltips for the buttons in the toolbar.
         """
         super().__init__()
+        self._buttons = buttons
+        """The buttons to show in the toolbar."""
+        self._commands = {command.__name__: command for command in commands}
+        """The commands available to the toolbar."""
         self._can_focus_buttons = can_focus
         """Whether the buttons in the toolbar can be focused."""
         self._show_button_tooltips = show_tooltips
         """Whether to show tooltips for the buttons in the toolbar."""
-        self._commands = commands
-        """The commands to show in the toolbar."""
 
     def compose(self) -> ComposeResult:
         """Compose the toolbar."""
-        for toolbar_button in self._commands:
+        for toolbar_button in self._buttons:
             try:
                 command_name, title = (
                     toolbar_button
@@ -163,7 +167,7 @@ class Toolbar(Horizontal):
                     "Invalid command button configuration item"
                 )
                 continue
-            if command := getattr(commands, command_name, None):
+            if command := self._commands.get(command_name):
                 yield CommandButton(
                     command=command,
                     title=title,

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -131,7 +131,7 @@ class Toolbar(Horizontal):
 
     def __init__(
         self,
-        buttons: list[str | list[str]],
+        buttons: Iterable[str | list[str]],
         commands: Iterable[type[Command]],
         can_focus: bool = False,
         show_tooltips: bool = True,
@@ -145,7 +145,7 @@ class Toolbar(Horizontal):
             show_tooltips: Whether to show tooltips for the buttons in the toolbar.
         """
         super().__init__()
-        self._buttons = buttons
+        self._buttons = list(buttons)
         """The buttons to show in the toolbar."""
         self._commands = {command.__name__: command for command in commands}
         """The commands available to the toolbar."""

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -2,7 +2,8 @@
 
 ##############################################################################
 # Python imports.
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 ##############################################################################
 # Textual imports.

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -20,10 +20,6 @@ from textual.widgets import Label
 from textual_enhanced.commands import Command
 from textual_enhanced.commands.bindings import primary_key_for
 
-##############################################################################
-# Local imports.
-from .. import __version__
-
 
 ##############################################################################
 class CommandButton(Widget):

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -133,6 +133,7 @@ class Toolbar(Horizontal):
         self,
         buttons: Iterable[str | list[str]],
         commands: Iterable[type[Command]],
+        version: str | None = None,
         can_focus: bool = False,
         show_tooltips: bool = True,
     ):
@@ -141,6 +142,7 @@ class Toolbar(Horizontal):
         Args:
             buttons: The buttons to show in the toolbar.
             commands: The commands available to the toolbar.
+            version: The version to show in the toolbar.
             can_focus: Whether the toolbar can be focused.
             show_tooltips: Whether to show tooltips for the buttons in the toolbar.
         """
@@ -149,6 +151,8 @@ class Toolbar(Horizontal):
         """The buttons to show in the toolbar."""
         self._commands = {command.__name__: command for command in commands}
         """The commands available to the toolbar."""
+        self._version = version
+        """The version to show in the toolbar."""
         self._can_focus_buttons = can_focus
         """Whether the buttons in the toolbar can be focused."""
         self._show_button_tooltips = show_tooltips
@@ -179,7 +183,8 @@ class Toolbar(Horizontal):
                 yield Label(command_name, markup=False, classes="error").with_tooltip(
                     f"{command_name} is an unknown command"
                 )
-        yield Label(f"v{__version__}", id="version")
+        if self._version:
+            yield Label(f"v{self._version}", id="version")
 
     def _bindings_updated(self, screen: Screen[Any]) -> None:
         """React to the bindings being updated on the screen.


### PR DESCRIPTION
Adds a configurable toolbar of application command buttons. Mainly aimed at being a mouse-only feature, but can be configured to allow entry with the keyboard too. The idea here being that keyboard shortcuts are the way to get to commands, followed by the command palette; the toolbar is there for when your hand is idle on the mouse and you don't want to go back to the keyboard.

<img width="1388" height="1298" alt="Screenshot 2026-08-18 at 16 06 36" src="https://github.com/user-attachments/assets/2ed5d28f-8726-482a-911f-82abe77a511b" />

Comes with a set of configuration options:

```json
    "toolbar_visible": true,
    "toolbar_contents": [
        [
            "GoHome",
            "\u2302"
        ],
        [
            "Reload",
            "\u21bb"
        ],
        [
            "Backward",
            "\u25c0\u25c0"
        ],
        [
            "Forward",
            "\u25b6\u25b6"
        ],
        [
            "GoToParent",
            "\u2191"
        ],
        [
            "GoToRoot",
            "\u21c8"
        ],
        [
            "SearchHistory",
            "\u25f7"
        ],
        [
            "SearchBookmarks",
            "\u2605"
        ],
        [
            "ToggleView",
            "\u21cb"
        ]
    ],
    "toolbar_can_get_focus": false,
    "toolbar_tooltips": true
```

## TODO

- [x] Add documentation

Closes #351 
Closes #354 
