### PR TITLE
Fix the default expiry date for client certificates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Rogallo ChangeLog
 
+## Unrelased
+
+**Released: WiP**
+
+- Fixed default client certificate expiry date being too short.
+  ([#374](https://github.com/davep/rogallo/pull/374))
+
 ## v1.12.0
 
 **Released: 2026-08-22**

--- a/src/rogallo/screens/certificate.py
+++ b/src/rogallo/screens/certificate.py
@@ -178,6 +178,7 @@ class Certificate(ModalScreen[CertificateData | None]):
         certificate_data: CertificateData = {
             "uri": self._scoped_location(),
             "transient": self.query_one("#transient", Checkbox).value,
+            "valid_days": None,
         }
         self._maybe_add(certificate_data, "common_name")
         try:


### PR DESCRIPTION
A value of 0 should have been until 9999-12-31, instead it was defaulting to a year.