### PR TITLE
Improve performance when navigating document with lots of links

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,8 @@
   name are now considered to be a request to visit a host of that protocol
   (`gopher.example.com` -> `gopher://gopher.example.com/1`, etc).
   ([#381](https://github.com/davep/rogallo/pull/381))
+- Improve link navigation performance in documents with a huge number of
+  links. ([#383](https://github.com/davep/rogallo/pull/383))
 
 ## v1.12.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,9 @@
   ([#381](https://github.com/davep/rogallo/pull/381))
 - Improve link navigation performance in documents with a huge number of
   links. ([#383](https://github.com/davep/rogallo/pull/383))
+- <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> no longer navigate
+  through links, but instead only navigate through the higher-level user
+  interface elements. ([#383](https://github.com/davep/rogallo/pull/383))
 
 ## v1.12.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,7 +32,7 @@
   name are now considered to be a request to visit a host of that protocol
   (`gopher.example.com` -> `gopher://gopher.example.com/1`, etc).
   ([#381](https://github.com/davep/rogallo/pull/381))
-- Improve link navigation performance in documents with a huge number of
+- Improved link navigation performance in documents with a huge number of
   links. ([#383](https://github.com/davep/rogallo/pull/383))
 - <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> no longer navigate
   through links, but instead only navigate through the higher-level user

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -6,6 +6,7 @@ from argparse import Namespace
 from collections.abc import Awaitable
 from functools import partial
 from subprocess import CalledProcessError, run
+from typing import Final
 from webbrowser import open as open_in_browser
 
 ##############################################################################
@@ -171,18 +172,15 @@ class Main(EnhancedScreen[None]):
             scrollbar-background-active: $surface;
         }
 
-        *:focus, *:focus-within {
-            scrollbar-background: $panel 80%;
-            scrollbar-background-hover: $panel 80%;
-            scrollbar-background-active: $panel 80%;
-        }
-
         .panel {
             border-left: solid $panel;
             background: $surface;
-            &:focus, &:focus-within {
+            &.--active-panel {
                 border-left: solid $border;
-                background: $panel 80%;
+                background: $panel;
+                scrollbar-background: $panel 80%;
+                scrollbar-background-hover: $panel 80%;
+                scrollbar-background-active: $panel 80%;
             }
         }
 
@@ -283,6 +281,24 @@ class Main(EnhancedScreen[None]):
         """The last user input."""
         self._clients = Clients.create()
         """The clients for the supported protocols."""
+
+    _ACTIVE: Final[str] = "--active-panel"
+    """The CSS class for the active panel."""
+
+    def _watch_focused(self):
+        """Watch for changes to the focused widget.
+
+        This is a workaround for Textual's poor performance when using
+        :focus-within.
+        """
+        super()._watch_focused()
+        ancestors = (
+            set(focused.ancestors_with_self)
+            if (focused := self.focused) is not None
+            else ()
+        )
+        self._side_panel.set_class(self._side_panel in ancestors, self._ACTIVE)
+        self._viewer.set_class(self._viewer in ancestors, self._ACTIVE)
 
     def _watch__side_panel_visible(self) -> None:
         """Watch for changes to the side panel visibility."""

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -285,13 +285,12 @@ class Main(EnhancedScreen[None]):
     _ACTIVE: Final[str] = "--active-panel"
     """The CSS class for the active panel."""
 
-    def _watch_focused(self):
+    def watch_focused(self) -> None:
         """Watch for changes to the focused widget.
 
         This is a workaround for Textual's poor performance when using
         :focus-within.
         """
-        super()._watch_focused()
         ancestors = (
             set(focused.ancestors_with_self)
             if (focused := self.focused) is not None

--- a/src/rogallo/widgets/side_panel/widget.py
+++ b/src/rogallo/widgets/side_panel/widget.py
@@ -52,8 +52,8 @@ class SidePanel(Container):
             dock: right;
         }
 
-        #tabs-list {
-            background: $panel;
+        #tabs-list, Tabs {
+            background: transparent;
         }
     }
     """

--- a/src/rogallo/widgets/viewer/document_view.py
+++ b/src/rogallo/widgets/viewer/document_view.py
@@ -6,7 +6,7 @@ from textual_enhanced.containers import EnhancedVerticalScroll
 
 
 ##############################################################################
-class DocumentView(EnhancedVerticalScroll):
+class DocumentView(EnhancedVerticalScroll, can_focus_children=False):
     """The scrolling container for the document."""
 
     HELP = """

--- a/src/rogallo/widgets/viewer/document_view.py
+++ b/src/rogallo/widgets/viewer/document_view.py
@@ -16,7 +16,5 @@ class DocumentView(EnhancedVerticalScroll):
     keys are available for movement within the document:
     """
 
-    DEFAULT_CLASSES = "panel"
-
 
 ### document_view.py ends here

--- a/src/rogallo/widgets/viewer/gemtext/content_filter.py
+++ b/src/rogallo/widgets/viewer/gemtext/content_filter.py
@@ -41,7 +41,7 @@ class GemtextContent:
         Returns:
             The string with ANSI escape sequences stripped.
         """
-        return Text.from_ansi(text).plain if "\x1b" else text
+        return Text.from_ansi(text).plain if "\x1b" in text else text
 
     @staticmethod
     def _strip_emoji(text: str) -> str:

--- a/src/rogallo/widgets/viewer/gemtext/content_filter.py
+++ b/src/rogallo/widgets/viewer/gemtext/content_filter.py
@@ -41,7 +41,7 @@ class GemtextContent:
         Returns:
             The string with ANSI escape sequences stripped.
         """
-        return Text.from_ansi(text).plain
+        return Text.from_ansi(text).plain if "\x1b" else text
 
     @staticmethod
     def _strip_emoji(text: str) -> str:

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -116,6 +116,8 @@ class GemtextLink(Widget, can_focus=True):
         """The link data."""
         self._normalised_uri = link.uri
         """The normalised URI to use when opening the link."""
+        self._filtered_content: Text | str | None = None
+        """The filtered content of the link."""
 
     @property
     def normalised_uri(self) -> str:
@@ -196,7 +198,9 @@ class GemtextLink(Widget, can_focus=True):
 
         # Now the link text.
         link.add_column(ratio=1)
-        link_data.append(GemtextContent.filter(self._link))
+        if self._filtered_content is None:
+            self._filtered_content = GemtextContent.filter(self._link)
+        link_data.append(self._filtered_content)
 
         # If we're showing link numbers and they're not "cosy".
         if self.with_link_numbers and not self.cosy_link_numbers:

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -10,40 +10,27 @@ from urllib.parse import urlparse
 from gemtext import Line, Link
 
 ##############################################################################
-# Port70 imports.
-from port70 import GopherURI
-
-##############################################################################
-# Port1900 imports.
-from port1900 import NexURI
-
-##############################################################################
-# Sybaritic imports.
-from sybaritic import SpartanURI
+# Rich imports.
+from rich.table import Table
+from rich.text import Text
 
 ##############################################################################
 # Textual imports.
 from textual import on
-from textual.app import ComposeResult
-from textual.containers import Horizontal, HorizontalGroup
 from textual.events import Click
-from textual.getters import query_one
 from textual.reactive import var
-from textual.widgets import Label
+from textual.widget import Widget
 
 ##############################################################################
 # Textual enhanced imports.
 from textual_enhanced.binding import HelpfulBinding
 
 ##############################################################################
-# Wasat imports.
-from wasat import GeminiURI
-
-##############################################################################
 # Local imports.
 from ....data import load_configuration
 from ....messages import OpenLocation, OpenURI
 from ....preflight import (
+    has_navigable_path,
     is_finger_uri,
     is_gopher_uri,
     is_likely_capsule,
@@ -51,14 +38,20 @@ from ....preflight import (
     is_nex_uri,
     is_spartan_uri,
 )
+from ....safe_escape import escape
 from ....types import RogalloLocation, SpartanURINeedingData
 from .content_filter import GemtextContent
 from .icons import icon
 
 
 ##############################################################################
-class GemtextLink(Horizontal, can_focus=True):
+class GemtextLink(Widget, can_focus=True):
     """A widget for displaying a Gemtext link."""
+
+    COMPONENT_CLASSES = {
+        "gemtext-link--icon",
+        "gemtext-link--jump-number",
+    }
 
     DEFAULT_CSS = """
     GemtextLink {
@@ -66,25 +59,17 @@ class GemtextLink(Horizontal, can_focus=True):
         height: auto;
         pointer: pointer;
 
-        #icon {
+        & > .gemtext-link--icon {
             color: $text-primary;
             margin-right: 1;
             height: auto;
         }
 
-        &.--visited #icon {
+        &.--visited > .gemtext-link--icon {
             color: $text-primary 50%;
         }
 
-        #text-wrap {
-            height: auto;
-        }
-
-        #text {
-            margin-right: 2;
-        }
-
-        #jump {
+        & > .gemtext-link--jump-number {
             display: none;
             color: $text-muted 30%;
             height: 100%;
@@ -95,14 +80,8 @@ class GemtextLink(Horizontal, can_focus=True):
         }
 
         &:focus {
-            #text-wrap, #jump {
-                color: $block-cursor-foreground;
-                background: $block-cursor-background;
-            }
-            #jump {
-                color: $text;
-                text-style: bold;
-            }
+            color: $block-cursor-foreground;
+            background: $block-cursor-background !important;
         }
     }
     """
@@ -118,16 +97,15 @@ class GemtextLink(Horizontal, can_focus=True):
 
     visited: var[bool] = var(False, toggle_class="--visited")
     """Whether the link has been visited or not."""
+    with_link_numbers: var[bool] = var(True)
+    """Whether to show link numbers or not."""
+    cosy_link_numbers: var[bool] = var(False)
+    """Whether to show link numbers in a cosy way or not."""
     jump_number: var[int | None] = var(None)
     """The jump number for the link."""
 
     _normalised_uri: var[str] = var("")
     """The normalised URI to use when opening the link."""
-
-    _jump_link = query_one("#jump", Label)
-    """The jump link label."""
-    _icon = query_one("#icon", Label)
-    """The icon label."""
 
     def __init__(self, link: Line) -> None:
         """Initialize a Gemtext link widget.
@@ -171,12 +149,12 @@ class GemtextLink(Horizontal, can_focus=True):
             return
         if urlparse(self._normalised_uri).scheme:
             return
-        if isinstance(base_uri, (GeminiURI, GopherURI, SpartanURI, NexURI)):
+        if has_navigable_path(base_uri):
             self._normalised_uri = str(base_uri.resolve(self._link.uri))
         elif isinstance(base_uri, Path):
             self._normalised_uri = (base_uri.parent / self._link.uri).resolve().as_uri()
         if self.is_mounted:
-            self._icon.update(self._best_icon())
+            self.refresh()
 
     def _watch__normalised_uri(self) -> None:
         """Watch for changes to the normalised URI."""
@@ -184,9 +162,16 @@ class GemtextLink(Horizontal, can_focus=True):
             self.tooltip = self._normalised_uri
 
     @property
-    def _jump_link_content(self) -> str:
+    def _jump_link_content(self) -> str | Text:
         """Get the content for the jump link."""
-        return "" if self.jump_number is None else f"[{self.jump_number}]"
+        return (
+            ""
+            if self.jump_number is None
+            else Text(
+                escape(f"[{self.jump_number}]"),
+                style=self.get_component_rich_style("gemtext-link--jump-number"),
+            )
+        )
 
     def _watch_jump_number(self) -> None:
         """Watch for changes to the jump number."""
@@ -194,21 +179,45 @@ class GemtextLink(Horizontal, can_focus=True):
             self.jump_number is not None and not bool(self.jump_number % 2),
             "--stripe",
         )
-        if self.is_mounted:
-            self._jump_link.update(self._jump_link_content)
+        self.refresh()
 
-    def compose(self) -> ComposeResult:
-        """Compose the Gemtext link widget."""
-        yield Label(self._best_icon(), id="icon")
-        with HorizontalGroup():
-            with HorizontalGroup(id="text-wrap"):
-                yield Label(
-                    GemtextContent.filter(self._link),
-                    id="text",
-                    markup=False,
-                    shrink=True,
-                )
-            yield Label(self._jump_link_content, id="jump", markup=False)
+    def _watch_with_link_numbers(self) -> None:
+        """Watch for changes to the with_link_numbers property."""
+        self.refresh()
+
+    def _watch_cosy_link_numbers(self) -> None:
+        """Watch for changes to the cosy_link_numbers property."""
+        self.refresh()
+
+    def render(self) -> Table:
+        """Render the Gemtext link widget."""
+        link = Table.grid(expand=True)
+
+        # Icon is always first.
+        link.add_column(width=2)
+        link_data: list[str | Text] = [
+            Text(
+                self._best_icon(),
+                style=self.get_component_rich_style("gemtext-link--icon"),
+            )
+        ]
+
+        # Next is the link number, if we're showing them and they're "cosy".
+        if self.with_link_numbers and self.cosy_link_numbers:
+            link.add_column(width=len(self._jump_link_content) + 1)
+            link_data.append(self._jump_link_content)
+
+        # Now the link text.
+        link.add_column(ratio=1)
+        link_data.append(GemtextContent.filter(self._link))
+
+        # If we're showing link numbers and they're not "cosy".
+        if self.with_link_numbers and not self.cosy_link_numbers:
+            link.add_column(width=len(self._jump_link_content) + 1, justify="right")
+            link_data.append(self._jump_link_content)
+
+        link.add_row(*link_data)
+        return link
 
     def _navigate_to_uri(self) -> None:
         """Navigate to the normalised URI."""

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -2,6 +2,7 @@
 
 ##############################################################################
 # Python imports.
+from functools import cached_property
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -121,6 +122,7 @@ class GemtextLink(Widget, can_focus=True):
         """The normalised URI to use when opening the link."""
         return self._normalised_uri
 
+    @cached_property
     def _best_icon(self) -> str:
         """Get the best icon for the link based on its URI."""
         for checker, icon_name in (
@@ -182,7 +184,7 @@ class GemtextLink(Widget, can_focus=True):
         link.add_column(width=2)
         link_data: list[str | Text] = [
             Text(
-                self._best_icon(),
+                self._best_icon,
                 style=self.get_component_rich_style("gemtext-link--icon"),
             )
         ]

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -181,6 +181,9 @@ class GemtextLink(Widget, can_focus=True):
     def render(self) -> Table:
         """Render the Gemtext link widget."""
         link = Table.grid(expand=True)
+        link_jump: str | Text = (
+            self._jump_link_content if self.with_link_numbers else ""
+        )
 
         # Icon is always first.
         link.add_column(width=2)
@@ -193,8 +196,8 @@ class GemtextLink(Widget, can_focus=True):
 
         # Next is the link number, if we're showing them and they're "cosy".
         if self.with_link_numbers and self.cosy_link_numbers:
-            link.add_column(width=len(self._jump_link_content) + 1)
-            link_data.append(self._jump_link_content)
+            link.add_column(width=len(link_jump) + 1)
+            link_data.append(link_jump)
 
         # Now the link text.
         link.add_column(ratio=1)
@@ -204,8 +207,8 @@ class GemtextLink(Widget, can_focus=True):
 
         # If we're showing link numbers and they're not "cosy".
         if self.with_link_numbers and not self.cosy_link_numbers:
-            link.add_column(width=len(self._jump_link_content) + 1, justify="right")
-            link_data.append(self._jump_link_content)
+            link.add_column(width=len(link_jump) + 1, justify="right")
+            link_data.append(link_jump)
 
         link.add_row(*link_data)
         return link

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -100,7 +100,7 @@ class GemtextLink(Widget, can_focus=True):
     jump_number: reactive[int | None] = reactive(None)
     """The jump number for the link."""
 
-    _normalised_uri: var[str] = var("")
+    _normalised_uri: reactive[str] = reactive("")
     """The normalised URI to use when opening the link."""
 
     def __init__(self, link: Line) -> None:
@@ -149,7 +149,6 @@ class GemtextLink(Widget, can_focus=True):
             self._normalised_uri = str(base_uri.resolve(self._link.uri))
         elif isinstance(base_uri, Path):
             self._normalised_uri = (base_uri.parent / self._link.uri).resolve().as_uri()
-        self.refresh()
 
     def _watch__normalised_uri(self) -> None:
         """Watch for changes to the normalised URI."""

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -183,15 +183,19 @@ class GemtextLink(Horizontal, can_focus=True):
         if load_configuration().show_link_tooltips:
             self.tooltip = self._normalised_uri
 
+    @property
+    def _jump_link_content(self) -> str:
+        """Get the content for the jump link."""
+        return "" if self.jump_number is None else f"[{self.jump_number}]"
+
     def _watch_jump_number(self) -> None:
         """Watch for changes to the jump number."""
-        self._jump_link.update(
-            "" if self.jump_number is None else f"[{self.jump_number}]"
-        )
         self.set_class(
             self.jump_number is not None and not bool(self.jump_number % 2),
             "--stripe",
         )
+        if self.is_mounted:
+            self._jump_link.update(self._jump_link_content)
 
     def compose(self) -> ComposeResult:
         """Compose the Gemtext link widget."""
@@ -204,7 +208,7 @@ class GemtextLink(Horizontal, can_focus=True):
                     markup=False,
                     shrink=True,
                 )
-            yield Label(id="jump", markup=False)
+            yield Label(self._jump_link_content, id="jump", markup=False)
 
     def _navigate_to_uri(self) -> None:
         """Navigate to the normalised URI."""

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -149,8 +149,7 @@ class GemtextLink(Widget, can_focus=True):
             self._normalised_uri = str(base_uri.resolve(self._link.uri))
         elif isinstance(base_uri, Path):
             self._normalised_uri = (base_uri.parent / self._link.uri).resolve().as_uri()
-        if self.is_mounted:
-            self.refresh()
+        self.refresh()
 
     def _watch__normalised_uri(self) -> None:
         """Watch for changes to the normalised URI."""

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -70,9 +70,7 @@ class GemtextLink(Widget, can_focus=True):
         }
 
         & > .gemtext-link--jump-number {
-            display: none;
             color: $text-muted 30%;
-            height: 100%;
         }
 
         &:hover {

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -55,7 +55,7 @@ class GemtextLink(Widget, can_focus=True):
 
     DEFAULT_CSS = """
     GemtextLink {
-        margin: 0 2 0 0;
+        margin: 0 1 0 0;
         height: auto;
         pointer: pointer;
 

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -61,8 +61,6 @@ class GemtextLink(Widget, can_focus=True):
 
         & > .gemtext-link--icon {
             color: $text-primary;
-            margin-right: 1;
-            height: auto;
         }
 
         &.--visited > .gemtext-link--icon {

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -2,7 +2,6 @@
 
 ##############################################################################
 # Python imports.
-from functools import cached_property
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -103,6 +102,8 @@ class GemtextLink(Widget, can_focus=True):
 
     _normalised_uri: reactive[str] = reactive("")
     """The normalised URI to use when opening the link."""
+    _icon: reactive[str] = reactive("")
+    """The icon to display for the link."""
 
     def __init__(self, link: Line) -> None:
         """Initialize a Gemtext link widget.
@@ -124,7 +125,6 @@ class GemtextLink(Widget, can_focus=True):
         """The normalised URI to use when opening the link."""
         return self._normalised_uri
 
-    @cached_property
     def _best_icon(self) -> str:
         """Get the best icon for the link based on its URI."""
         for checker, icon_name in (
@@ -156,6 +156,7 @@ class GemtextLink(Widget, can_focus=True):
 
     def _watch__normalised_uri(self) -> None:
         """Watch for changes to the normalised URI."""
+        self._icon = self._best_icon()
         if load_configuration().show_link_tooltips:
             self.tooltip = self._normalised_uri
 
@@ -189,7 +190,7 @@ class GemtextLink(Widget, can_focus=True):
         link.add_column(width=2)
         link_data: list[str | Text] = [
             Text(
-                self._best_icon,
+                self._icon,
                 style=self.get_component_rich_style("gemtext-link--icon"),
             )
         ]

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -18,7 +18,7 @@ from rich.text import Text
 # Textual imports.
 from textual import on
 from textual.events import Click
-from textual.reactive import var
+from textual.reactive import reactive, var
 from textual.widget import Widget
 
 ##############################################################################
@@ -93,11 +93,11 @@ class GemtextLink(Widget, can_focus=True):
 
     visited: var[bool] = var(False, toggle_class="--visited")
     """Whether the link has been visited or not."""
-    with_link_numbers: var[bool] = var(True)
+    with_link_numbers: reactive[bool] = reactive(True)
     """Whether to show link numbers or not."""
-    cosy_link_numbers: var[bool] = var(False)
+    cosy_link_numbers: reactive[bool] = reactive(False)
     """Whether to show link numbers in a cosy way or not."""
-    jump_number: var[int | None] = var(None)
+    jump_number: reactive[int | None] = reactive(None)
     """The jump number for the link."""
 
     _normalised_uri: var[str] = var("")
@@ -174,15 +174,6 @@ class GemtextLink(Widget, can_focus=True):
             self.jump_number is not None and not bool(self.jump_number % 2),
             "--stripe",
         )
-        self.refresh()
-
-    def _watch_with_link_numbers(self) -> None:
-        """Watch for changes to the with_link_numbers property."""
-        self.refresh()
-
-    def _watch_cosy_link_numbers(self) -> None:
-        """Watch for changes to the cosy_link_numbers property."""
-        self.refresh()
 
     def render(self) -> Table:
         """Render the Gemtext link widget."""

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -132,7 +132,7 @@ class Viewer(Vertical, can_focus=False):
             tooltip="Move backwards through each of the links",
         ),
         HelpfulBinding(
-            "right, shift+down, l",
+            "right, shift+down, l, n",
             "next_link",
             tooltip="Move forward through each of the links",
         ),

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -522,25 +522,31 @@ class Viewer(Vertical, can_focus=False):
 
     def action_previous_link(self) -> None:
         """Focus the previous link."""
-        if not (links := self._view.query(GemtextLink)):
+        if not self._jump_map:
             return
-        current = self._view.query_one_optional("GemtextLink:focus", GemtextLink)
-        if current is None or (current.jump_number and current.jump_number <= 1):
-            self.jump = links.last().jump_number
-        elif current.jump_number is not None:
-            self.jump = current.jump_number - 1
+        current = (
+            focused.jump_number
+            if isinstance(focused := self.screen.focused, GemtextLink)
+            else None
+        )
+        if current is None or current <= 1:
+            self.jump = len(self._jump_map)
+        else:
+            self.jump = current - 1
 
     def action_next_link(self) -> None:
         """Focus the next link."""
-        if not (links := self._view.query(GemtextLink)):
+        if not self._jump_map:
             return
-        current = self._view.query_one_optional("GemtextLink:focus", GemtextLink)
-        if (last := links.last().jump_number) is None:
-            return
-        if current is None or (current.jump_number and current.jump_number >= last):
+        current = (
+            focused.jump_number
+            if isinstance(focused := self.screen.focused, GemtextLink)
+            else None
+        )
+        if current is None or current >= len(self._jump_map):
             self.jump = 1
-        elif current.jump_number is not None:
-            self.jump = current.jump_number + 1
+        else:
+            self.jump = current + 1
 
 
 ### widget.py ends here

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -418,9 +418,10 @@ class Viewer(Vertical, can_focus=False):
         self._status.mime_type = self.document.mime_type or ""
         self._jump_map = {}
         with self.app.batch_update():
-            await self._view.remove_children()
-            await self._view.mount_all(self._build_content())
-            if not self.view_source and len(links := self._view.query(GemtextLink)):
+            content = self._build_content()
+            if not self.view_source and len(
+                links := [link for link in content if isinstance(link, GemtextLink)]
+            ):
                 visited_links = {
                     str(visit.location)
                     for visit in self.location_history
@@ -433,6 +434,8 @@ class Viewer(Vertical, can_focus=False):
                     link.visited = link.normalised_uri in visited_links
                     link.jump_number = jump_number + 1
                     self._jump_map[link.jump_number] = link
+            await self._view.remove_children()
+            await self._view.mount_all(content)
         # This next bit of nonsense is because Textual fails to sort its
         # scrollbars out upon clearing down and remounting a new set of
         # children. So we have to force it to refresh and then scroll to the

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -106,15 +106,6 @@ class Viewer(Vertical, can_focus=False):
                 background: $background 60%;
             }
         }
-
-        &.--with-link-numbers GemtextLink #jump {
-            display: block;
-        }
-
-        &.--cosy-link-numbers GemtextLink #jump {
-            dock: left;
-            padding-right: 1;
-        }
     }
     """
 
@@ -142,9 +133,9 @@ class Viewer(Vertical, can_focus=False):
     """The details of the document to show in the viewer."""
     view_source: var[bool] = var(False)
     """Whether the viewer is showing the source of the document or not."""
-    with_link_numbers: var[bool] = var(False, toggle_class="--with-link-numbers")
+    with_link_numbers: var[bool] = var(False)
     """Whether the viewer is showing link numbers or not."""
-    cosy_link_numbers: var[bool] = var(False, toggle_class="--cosy-link-numbers")
+    cosy_link_numbers: var[bool] = var(False)
     """Whether the viewer is showing link numbers in a cosy way or not."""
     stripe_links: var[bool] = var(False, toggle_class="--stripe-links")
     """Whether the viewer is showing links with stripes or not."""
@@ -430,6 +421,7 @@ class Viewer(Vertical, can_focus=False):
                     )
                 }
                 for jump_number, link in enumerate(links):
+                    link.data_bind(Viewer.with_link_numbers, Viewer.cosy_link_numbers)
                     link.normalise_uri(self.document.location)
                     link.visited = link.normalised_uri in visited_links
                     link.jump_number = jump_number + 1

--- a/src/rogallo/widgets/viewer/widget.py
+++ b/src/rogallo/widgets/viewer/widget.py
@@ -118,6 +118,8 @@ class Viewer(Vertical, can_focus=False):
     }
     """
 
+    DEFAULT_CLASSES = "panel"
+
     HELP = """
     As well as the normal widget navigation keys, the following keys are
     available to navigate through the links:


### PR DESCRIPTION
Changes to improve link navigation speed:

- Use of Textual's `:focus-within` degrades performance in a surprising way. So rather than using CSS to handle the styling of the focused panels, do it within code.
- Don't query the DOM when doing next/previous link navigation
- Stop use of normal next/previous focus switching for navigating links (kind of a breaking change, but also improves navigation of the application as a whole and encourages the more efficient link navigation mechanism)
- Link widgets are now a single widget that uses a renderable, rather than a compound widget.

Also some changes to improve documentation creation/mount time:

- Don't call `from_ansi` on content that obviously has no escape sequences.
- Set up all the jump numbers *before* mounting the document to avoid expensive Textual behaviour.

Closes #202.