### PR TITLE
Change the location of the online ChangeLog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,9 @@
   ([#385](https://github.com/davep/rogallo/pull/385))
 - When removing emoji, any space directly following an emoji is also
   removed. ([#386](https://github.com/davep/rogallo/pull/386))
+- Updated the in-app ChangeLog link to my Gemcities capsule due to
+  tilde.team having a long-term outage.
+  ([#388](https://github.com/davep/rogallo/pull/388))
 
 ## v1.12.1
 

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -967,7 +967,7 @@ class Main(EnhancedScreen[None]):
 
     def action_view_change_log_command(self) -> None:
         """View the change log."""
-        self.post_message(OpenURI("gemini://tilde.team/~davep/rogallo/changelog.gmi"))
+        self.post_message(OpenURI("gemini://davep.gemcities.com/rogallo/changelog.gmi"))
 
     def action_hand_off_to_operating_system_command(self) -> None:
         """Hand off the current document's location to the operating system."""


### PR DESCRIPTION
tilde.team is having a long-term outage, so it's time to point this to a new location for now.

Closes #377.