### PR TITLE
Add support for forgetting a trusted host

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
   ([#395](https://github.com/davep/rogallo/pull/395))
 - Adjusted the styling of tooltips so they stand out better no matter what
   is under them. ([#396](https://github.com/davep/rogallo/pull/396))
+- Added the ability to forget a known host when encountering a security
+  issue. ([#398](https://github.com/davep/rogallo/pull/398))
 
 ## v2.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "textual-fspicker>=1.0.1",
     "types-pygments>=2.20.0.20260518",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=1.6.0",
+    "wasat>=1.7.0",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/src/rogallo/screens/main/handlers/gemini.py
+++ b/src/rogallo/screens/main/handlers/gemini.py
@@ -35,6 +35,7 @@ from ...client_certificate import (
     ClientCertificatePickerResult,
     LocationSpecificClientCertificateMaker,
 )
+from ...security_alert import SecurityAlert
 from ...user_input import UserInput
 from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
 
@@ -242,6 +243,28 @@ async def _handle_response(
 
 
 ##############################################################################
+async def _handle_security_error(
+    client: Client, error: SecurityError, uri: GeminiURI, owner: Widget
+) -> None:
+    """Handle a security error from a Gemini request.
+
+    Args:
+        error: The security error to handle.
+        uri: The URI that caused the security error.
+        owner: The widget that owns the request.
+    """
+    if await owner.app.push_screen_wait(SecurityAlert(uri, str(error))):
+        assert client.trust_store is not None
+        await client.trust_store.forget(uri.host, uri.port)
+        owner.post_message(OpenLocation(uri, allow_cached=False))
+        owner.notify(
+            f"Reset the trust status for {uri.host}:{uri.port}",
+            title="Security Alert",
+            severity="warning",
+        )
+
+
+##############################################################################
 async def handle_gemini_request(
     request: OpenLocation,
     owner: Widget,
@@ -294,11 +317,7 @@ async def handle_gemini_request(
             title="Connection Error",
         )
     except SecurityError as error:
-        owner.notify(
-            f"Error loading {uri}:\n\n{error}",
-            severity="error",
-            title="Security Error",
-        )
+        await _handle_security_error(client, error, uri, owner)
 
 
 ### gemini.py ends here

--- a/src/rogallo/screens/security_alert.py
+++ b/src/rogallo/screens/security_alert.py
@@ -1,0 +1,99 @@
+"""Provides a security alert screen for the Rogallo application."""
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import HorizontalGroup, VerticalGroup
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label
+
+##############################################################################
+# Textual enhanced imports.
+from textual_enhanced.tools import add_key
+
+##############################################################################
+# Local imports.
+from ..types import RogalloLocation
+
+
+##############################################################################
+class SecurityAlert(ModalScreen[bool]):
+    """A modal screen to display a security alert."""
+
+    CSS = """
+    SecurityAlert {
+        align: center middle;
+
+        &> VerticalGroup {
+            width: 60%;
+            height: auto;
+            background: $panel;
+            border: panel $border;
+        }
+
+        Label {
+            padding: 1 2;
+            height: auto;
+        }
+
+        Button {
+            margin-right: 1;
+        }
+
+        #buttons {
+            height: auto;
+            margin-top: 1;
+            align-horizontal: right;
+        }
+    }
+    """
+
+    BINDINGS = [("f", "forget"), ("escape", "cancel")]
+
+    def __init__(self, uri: RogalloLocation, message: str) -> None:
+        """Initialise the screen.
+
+        Args:
+            location (RogalloLocation): The location of the security alert.
+            message (str): The security alert message.
+        """
+        super().__init__()
+        self._uri = uri
+        """The location of the security alert."""
+        self._message = message
+        """The security alert message."""
+
+    def compose(self) -> ComposeResult:
+        """Compose the screen.
+
+        Returns:
+            The composed screen.
+        """
+        with VerticalGroup() as dialog:
+            dialog.border_title = "Security error!"
+            yield Label(f"Security alert for {self._uri}", shrink=True, markup=False)
+            yield Label(self._message, shrink=True, markup=False, variant="error")
+            yield Label(
+                "You can choose to forget the certificate and try again, or cancel the connection. "
+                "NOTE: There are a number of reasons why you might be seeing this error. "
+                "If you are unsure, it is recommended to cancel the connection and investigate further.",
+                shrink=True,
+                markup=False,
+            )
+            with HorizontalGroup(id="buttons"):
+                yield Button(add_key("Cancel", "Esc"), id="cancel", variant="primary")
+                yield Button(add_key("Forget", "f"), id="forget", variant="error")
+
+    @on(Button.Pressed, "#cancel")
+    def action_cancel(self) -> None:
+        """Cancel the security alert."""
+        self.dismiss(False)
+
+    @on(Button.Pressed, "#forget")
+    def action_forget(self) -> None:
+        """Forget the certificate and try again."""
+        self.dismiss(True)
+
+
+### security_alert.py ends here

--- a/src/rogallo/screens/security_alert.py
+++ b/src/rogallo/screens/security_alert.py
@@ -73,13 +73,12 @@ class SecurityAlert(ModalScreen[bool]):
         with VerticalGroup() as dialog:
             dialog.border_title = "Security error!"
             yield Label(f"Security alert for {self._uri}", shrink=True, markup=False)
-            yield Label(self._message, shrink=True, markup=False, variant="error")
+            yield Label(self._message, shrink=True, variant="error")
             yield Label(
                 "You can choose to forget the certificate and try again, or cancel the connection. "
                 "NOTE: There are a number of reasons why you might be seeing this error. "
                 "If you are unsure, it is recommended to cancel the connection and investigate further.",
                 shrink=True,
-                markup=False,
             )
             with HorizontalGroup(id="buttons"):
                 yield Button(add_key("Cancel", "Esc"), id="cancel", variant="primary")

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ requires-dist = [
     { name = "textual-fspicker", specifier = ">=1.0.1" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=1.6.0" },
+    { name = "wasat", specifier = ">=1.7.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -2077,14 +2077,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "1.6.0"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/73/709c55daf3aae901becb8faa335dcbe02a3aefe43960999ca97a2f6f0041/wasat-1.6.0.tar.gz", hash = "sha256:9c41312bd46cfa8f072beda060f330f0940265828e86086d4363f13575dced7b", size = 33270, upload-time = "2026-08-27T08:24:37.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/428a8c8d5071df67e07912c637f25b591dac5fa006847b326de2281edfda/wasat-1.7.0.tar.gz", hash = "sha256:a3d0c21a89b60ddf9ea3838d2c7930935892703e1b7410a7b6c128b9e46f0c1a", size = 33377, upload-time = "2026-08-30T10:25:42.585Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/6f/6092640dd43edd79a274860ef167865355cab9d335fe6c8439175728794e/wasat-1.6.0-py3-none-any.whl", hash = "sha256:8b0d9c3a3bbed05b39b6cc682b223881380174b95d0f2df8554341ff011183ef", size = 37015, upload-time = "2026-08-27T08:24:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/37/9d/8b110c8fb5075340281ff267beff0a0169bf1a0b2737f44d16ce007dc9bd/wasat-1.7.0-py3-none-any.whl", hash = "sha256:8b84f34a9ddc072e7dee6a16cf5c83b354311eb51b078b310855b1d749e2bb7f", size = 37126, upload-time = "2026-08-30T10:25:41.484Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Whereas before you'd just get a toast to say the site wasn't being loaded...

<img width="544" height="217" alt="Image" src="https://github.com/user-attachments/assets/bb981981-ef85-41a1-b3b1-ab6af528b4a0" />

Now you get a modal that allows you to either cancel, or forget the site and try again.

<img width="767" height="332" alt="Screenshot 2026-08-30 at 11 54 25" src="https://github.com/user-attachments/assets/2f1df15f-f440-4699-ab8c-9191b5f9d954" />

Closes #148.
