### PR TITLE
Ensure BOMs are handled and don't throw off parsing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@
   issue. ([#398](https://github.com/davep/rogallo/pull/398))
 - Fixed the cosmetics of the viewer when it's in a narrowed state.
   ([#399](https://github.com/davep/rogallo/pull/399))
+- Handle BOMs at the start of received content.
+  ([#403](https://github.com/davep/rogallo/pull/403))
 
 ## v2.0.0
 

--- a/src/rogallo/text_decoder.py
+++ b/src/rogallo/text_decoder.py
@@ -12,6 +12,25 @@ from wasat import Response as GeminiResponse
 
 
 ##############################################################################
+def _best_encoding(response: GeminiResponse | SpartanResponse) -> dict[str, str]:
+    """Determine the best encoding to use for decoding the response.
+
+    Args:
+        response: The response to determine the encoding for.
+
+    Returns:
+        The best encoding to use for decoding the response.
+    """
+    if response.charset:
+        return {
+            "encoding": "utf-8-sig"
+            if response.charset.lower() == "utf-8"
+            else response.charset
+        }
+    return {}
+
+
+##############################################################################
 async def decode_text(response: GeminiResponse | SpartanResponse) -> str:
     """Decode the text from a response.
 
@@ -24,7 +43,7 @@ async def decode_text(response: GeminiResponse | SpartanResponse) -> str:
     try:
         # Give the library a chance to decode the text using the charset
         # specified in the response headers.
-        return await response.text(encoding="utf-8-sig")
+        return await response.text(**_best_encoding(response))
     except (GeminiProtocolError, SpartanResponseError):
         # If the library fails to decode the text, fall back to latin-1.
         return await response.text(encoding="latin-1")

--- a/src/rogallo/text_decoder.py
+++ b/src/rogallo/text_decoder.py
@@ -24,7 +24,7 @@ async def decode_text(response: GeminiResponse | SpartanResponse) -> str:
     try:
         # Give the library a chance to decode the text using the charset
         # specified in the response headers.
-        return await response.text()
+        return await response.text(encoding="utf-8-sig")
     except (GeminiProtocolError, SpartanResponseError):
         # If the library fails to decode the text, fall back to latin-1.
         return await response.text(encoding="latin-1")


### PR DESCRIPTION
Right now just a quick check (and this fixes the issue for Gemtext from a Capsule or from a Spartan server). But I should check how I handle Gemtext from other sources too.

I suspect I mostly need to go through anywhere where I get content and decode with `utf-8-sig` rather than `utf-8`.

Closes #402.