### PR TITLE
Only show panel borders when multiple panels are open

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Rogallo ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Changed the active panel border styling so that the left-hand border is
+  only visible when the side panel is open, saving one horizontal character
+  of space for viewing when only the viewer is open.
+  ([#405](https://github.com/davep/rogallo/pull/405))
+
 ## v2.1.0
 
 **Released: 2026-08-31**

--- a/src/rogallo/screens/main/screen.py
+++ b/src/rogallo/screens/main/screen.py
@@ -173,12 +173,10 @@ class Main(EnhancedScreen[None]):
         }
 
         SidePanel, Viewer DocumentView {
-            border-left: solid $panel;
             background: $surface;
         }
 
         SidePanel.--active-panel, Viewer.--active-panel DocumentView {
-            border-left: solid $border;
             background: $panel;
             scrollbar-background: $panel 80%;
             scrollbar-background-hover: $panel 80%;
@@ -188,8 +186,18 @@ class Main(EnhancedScreen[None]):
         SidePanel {
             display: none;
         }
-        &.--side-panel SidePanel {
-            display: block;
+
+        &.--side-panel-visible {
+            SidePanel {
+                display: block;
+            }
+
+            SidePanel, Viewer DocumentView {
+                border-left: solid $panel;
+            }
+            SidePanel.--active-panel, Viewer.--active-panel DocumentView {
+                border-left: solid $border;
+            }
         }
     }
 
@@ -260,7 +268,7 @@ class Main(EnhancedScreen[None]):
     """The bookmarks."""
     _client_certificates: var[list[ClientCertificate]] = var(list)
     """The client certificates."""
-    _side_panel_visible: var[bool] = var(False, toggle_class="--side-panel")
+    _side_panel_visible: var[bool] = var(False, toggle_class="--side-panel-visible")
     """Whether the side panel is visible."""
 
     def __init__(self, arguments: Namespace) -> None:


### PR DESCRIPTION
Makes the main display a wee bit cleaner when only the viewer is showing; also saves 1 character of horizontal space.