### PR TITLE
Add Titan support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,8 +7,8 @@
 - Fixed Rogallo not playing well with the scriptonite examples found at
   gemini://ultimatumlabs.com/scripto.gmi.
   ([#415](https://github.com/davep/rogallo/pull/415))
-
-**Released: 2026-09-03**
+- Added support for the Titan Protocol.
+  ([#417](https://github.com/davep/rogallo/pull/417))
 
 ## v2.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
   ([#415](https://github.com/davep/rogallo/pull/415))
 - Added support for the Titan Protocol.
   ([#417](https://github.com/davep/rogallo/pull/417))
+- Added support for the edit extension to the Titan protocol.
+  ([#417](https://github.com/davep/rogallo/pull/417))
 
 ## v2.2.0
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rogallo is a terminal-based client for browsing
 [Fingerspace](https://en.wikipedia.org/wiki/Finger_(protocol)). Its key
 features include:
 
-- Support for the `gemini`, `spartan`, `gopher`, `nex` and `finger` protocols
+- Support for the `gemini`, `titan`, `spartan`, `gopher`, `nex` and `finger` protocols
 - Bookmarks management with search
 - Location history tracking with search
 - Backward and forward page navigation

--- a/docs/screenshots/titan_screenshot.py
+++ b/docs/screenshots/titan_screenshot.py
@@ -1,0 +1,10 @@
+"""Generate screenshots related to Titan."""
+
+from support.maker import make_app
+
+app = make_app("titan")
+
+if __name__ == "__main__":
+    app.run()
+
+### titan.py ends here

--- a/docs/server/public_gemini/features.gmi
+++ b/docs/server/public_gemini/features.gmi
@@ -3,7 +3,7 @@
 Rogallo is a terminal-based client for browsing Geminispace, Spartanspace, Gopherspace, Nexspace, and Fingerspace. Its key
 features include:
 
-* Support for the `gemini`, `spartan`, `gopher`, `nex`, and `finger` protocols
+* Support for the `gemini`, `titan`, `spartan`, `gopher`, `nex`, and `finger` protocols
 * Bookmarks management with search
 * Location history tracking with search
 * Backward and forward page navigation

--- a/docs/server/public_gemini/titan.gmi
+++ b/docs/server/public_gemini/titan.gmi
@@ -1,0 +1,6 @@
+# Titan upload example
+
+This is a page that includes a Titan link, which can be used to upload text or a file.
+
+=> titan://localhost/titan.gmi Upload something bigger than usual
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -11,7 +11,7 @@ Rogallo is a terminal-based client for browsing
 [Fingerspace](https://en.wikipedia.org/wiki/Finger_(protocol)). Its key
 features include:
 
-- Support for the `gemini`, `spartan`, `gopher`, `nex` and `finger` protocols
+- Support for the `gemini`, `titan`, `spartan`, `gopher`, `nex` and `finger` protocols
 - Bookmarks management with search
 - Location history tracking with search
 - Backward and forward page navigation

--- a/docs/source/protocols.md
+++ b/docs/source/protocols.md
@@ -7,5 +7,6 @@ Rogallo supports the following protocols:
 - [Gopher](./gopher.md)
 - [Nex](./nex.md)
 - [Spartan](./spartan.md)
+- [Titan](./titan.md)
 
 [//]: # (protocols.md ends here)

--- a/docs/source/titan.md
+++ b/docs/source/titan.md
@@ -1,0 +1,27 @@
+# Titan
+
+## Introduction
+
+Closely related to the [Gemini Protocol](./gemini.md), Rogallo also has
+support for the [Titan Protocol](https://communitywiki.org/wiki/Titan). When
+presented with a `titan://` URI Rogallo will allow you to enter and submit
+text, or select and upload a file.
+
+## Text entry and submission
+
+The Titan-related dialog has a tabbed view. If the first tab is selected the
+intention is that you enter your text and submit it.
+
+```{.textual path="docs/screenshots/titan_screenshot.py" title="Titan text entry" lines=50 columns=100 press="right,enter,tab"}
+```
+
+## File upload submission
+
+If you select the `File` tab you have the ability to select a file from the
+filesystem and specify its mime type (this will be set for you when you
+select a file).
+
+```{.textual path="docs/screenshots/titan_screenshot.py" title="Titan file uploading" lines=50 columns=100 press="right,enter,ctrl+f,tab,tab"}
+```
+
+[//]: # (titan.md ends here)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - gopher.md
       - nex.md
       - spartan.md
+      - titan.md
   - "UI":
       - ui.md
       - command-line.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "textual-fspicker>=1.0.1",
     "types-pygments>=2.20.0.20260518",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=1.8.1",
+    "wasat>=1.9.0",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "textual-fspicker>=1.0.1",
     "types-pygments>=2.20.0.20260518",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=1.8.0",
+    "wasat>=1.8.1",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "textual-fspicker>=1.0.1",
     "types-pygments>=2.20.0.20260518",
     "types-pyperclip>=1.11.0.20260508",
-    "wasat>=1.9.0",
+    "wasat>=1.9.1",
     "xdg-base-dirs>=6.0.2",
 ]
 classifiers = [

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -114,6 +114,9 @@ class Configuration:
     nexspace_link_icon: str = "☽"
     """The icon to use for links to nex:// URIs."""
 
+    titanspace_link_icon: str = "⫸"
+    """The icon to use for links to titan:// URIs."""
+
     otherspace_link_icon: str = "↗"
     """The icon to use for non-gemini URIs."""
 

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -114,7 +114,7 @@ class Configuration:
     nexspace_link_icon: str = "☽"
     """The icon to use for links to nex:// URIs."""
 
-    titanspace_link_icon: str = "⫸"
+    titanspace_link_icon: str = "⩓"
     """The icon to use for links to titan:// URIs."""
 
     otherspace_link_icon: str = "↗"

--- a/src/rogallo/editor.py
+++ b/src/rogallo/editor.py
@@ -1,0 +1,61 @@
+"""Provides support for editing with an external editor."""
+
+##############################################################################
+# Python imports.
+from functools import cache
+from os import getenv
+from pathlib import Path
+from subprocess import run
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+##############################################################################
+# Textual imports.
+from textual.app import App
+
+##############################################################################
+# Local imports.
+from .data import load_configuration
+from .types import DEFAULT_GEMINI_EXTENSION
+
+
+##############################################################################
+@cache
+def external_editor() -> str | None:
+    """The external editor to use, if any."""
+    return (
+        load_configuration().external_editor
+        or getenv("VISUAL")
+        or getenv("EDITOR")
+        or None
+    )
+
+
+##############################################################################
+def edit_externally(application: App[Any], text: str) -> str:
+    """Edit the given text in an external editor.
+
+    Args:
+        text: The text to edit.
+
+    Returns:
+        The edited text, or the original text if no external editor is
+        configured.
+    """
+    if not (editor := external_editor()):
+        return text
+    with NamedTemporaryFile(
+        mode="w+", delete=False, encoding="utf-8", suffix=DEFAULT_GEMINI_EXTENSION
+    ) as temp_file:
+        user_input = Path(temp_file.name)
+        temp_file.write(text)
+        temp_file.close()
+        try:
+            with application.suspend():
+                run((editor, user_input))
+                return user_input.read_text(encoding="utf-8")
+        finally:
+            user_input.unlink(missing_ok=True)
+
+
+### editor.py ends here

--- a/src/rogallo/input_content.py
+++ b/src/rogallo/input_content.py
@@ -6,14 +6,14 @@ from typing import NamedTuple
 
 ##############################################################################
 # Wasat imports.
-from wasat import GeminiURI
+from wasat import AnyURI
 
 
 ##############################################################################
 class InputContent(NamedTuple):
     """A class for holding a user's input content."""
 
-    location: GeminiURI
+    location: AnyURI
     """The location that the input was requested from."""
     prompt: str
     """The prompt that was shown to the user."""

--- a/src/rogallo/preflight.py
+++ b/src/rogallo/preflight.py
@@ -29,7 +29,7 @@ from sybaritic import URIError as SpartanURIError
 
 ##############################################################################
 # Wasat imports.
-from wasat import GeminiURI
+from wasat import GeminiURI, TitanURI
 from wasat import URIError as GeminiURIError
 from wasat.uri import GEMINI_PREFIX
 
@@ -124,6 +124,23 @@ def is_nex_uri(uri: str) -> bool:
     try:
         _ = NexURI(uri)
     except NexURIError:
+        return False
+    return True
+
+
+##############################################################################
+def is_titan_uri(uri: str) -> bool:
+    """Determine if a URI is a Titan URI.
+
+    Args:
+        uri: The URI to check.
+
+    Returns:
+        `True` if the URI is a Titan URI, `False` otherwise.
+    """
+    try:
+        _ = TitanURI(uri)
+    except GeminiURIError:
         return False
     return True
 

--- a/src/rogallo/presentation.py
+++ b/src/rogallo/presentation.py
@@ -22,7 +22,7 @@ from sybaritic import SpartanURI
 
 ##############################################################################
 # Wasat imports.
-from wasat import GeminiURI
+from wasat import GeminiURI, TitanURI
 from wasat.uri import GEMINI_PREFIX
 
 ##############################################################################
@@ -40,7 +40,7 @@ def short_location(location: RogalloLocation) -> str:
     Returns:
         A short string representation of the location.
     """
-    if isinstance(location, (FingerURI, GopherURI, SpartanURI, NexURI)):
+    if isinstance(location, (FingerURI, GopherURI, SpartanURI, NexURI, TitanURI)):
         return str(location)
     if isinstance(location, GeminiURI):
         return str(location).removeprefix(GEMINI_PREFIX)

--- a/src/rogallo/screens/client_certificate/maker.py
+++ b/src/rogallo/screens/client_certificate/maker.py
@@ -21,7 +21,7 @@ from textual_enhanced.tools import add_key
 
 ##############################################################################
 # Wasat imports.
-from wasat import GeminiURI
+from wasat import AnyURI
 
 ##############################################################################
 type CertificateData = dict[str, Any]
@@ -190,7 +190,7 @@ class BaseCertificateMaker(ModalScreen[CertificateData | None]):
 class LocationSpecificClientCertificateMaker(BaseCertificateMaker):
     """A modal screen to get a certificate from the user."""
 
-    def __init__(self, location: GeminiURI, reason: str) -> None:
+    def __init__(self, location: AnyURI, reason: str) -> None:
         """Initialise the object.
 
         Args:

--- a/src/rogallo/screens/client_certificate/picker.py
+++ b/src/rogallo/screens/client_certificate/picker.py
@@ -21,7 +21,7 @@ from textual_enhanced.tools import add_key
 
 ##############################################################################
 # Wasat imports.
-from wasat import ClientCertificate, GeminiURI
+from wasat import AnyURI, ClientCertificate
 
 ##############################################################################
 type ClientCertificatePickerResult = ClientCertificate | Literal["create"] | None
@@ -90,9 +90,7 @@ class ClientCertificatePicker(ModalScreen[ClientCertificatePickerResult]):
     _certificate_choices = query_one(OptionList)
     """The option list that contains the certificate choices."""
 
-    def __init__(
-        self, uri: GeminiURI, certificates: Iterable[ClientCertificate]
-    ) -> None:
+    def __init__(self, uri: AnyURI, certificates: Iterable[ClientCertificate]) -> None:
         """Initialize the dialog.
 
         Args:

--- a/src/rogallo/screens/main/handlers/__init__.py
+++ b/src/rogallo/screens/main/handlers/__init__.py
@@ -8,6 +8,7 @@ from .gemini import LastInputGetter, LastInputSetter, handle_gemini_request
 from .gopher import handle_gopher_request
 from .nex import handle_nex_request
 from .spartan import handle_spartan_request
+from .titan import handle_titan_request
 
 ##############################################################################
 # Exports.
@@ -18,6 +19,7 @@ __all__ = [
     "handle_gopher_request",
     "handle_nex_request",
     "handle_spartan_request",
+    "handle_titan_request",
     "LastInputGetter",
     "LastInputSetter",
 ]

--- a/src/rogallo/screens/main/handlers/__init__.py
+++ b/src/rogallo/screens/main/handlers/__init__.py
@@ -2,9 +2,10 @@
 
 ##############################################################################
 # Local imports.
+from ._glv import LastInputGetter, LastInputSetter
 from .filesystem import handle_filesystem_request
 from .finger import handle_finger_request
-from .gemini import LastInputGetter, LastInputSetter, handle_gemini_request
+from .gemini import handle_gemini_request
 from .gopher import handle_gopher_request
 from .nex import handle_nex_request
 from .spartan import handle_spartan_request

--- a/src/rogallo/screens/main/handlers/_glv.py
+++ b/src/rogallo/screens/main/handlers/_glv.py
@@ -52,7 +52,7 @@ async def document(uri: AnyURI, request: OpenLocation, response: Response) -> Do
 async def handle_client_certificate_request(
     location: AnyURI, request_reason: str, client: Client, owner: Widget
 ) -> None:
-    """Handle a request for a client certificate from a Gemini request.
+    """Handle a request for a client certificate from a Gemini/Titan request.
 
     Args:
         location: The location making the request.
@@ -122,9 +122,10 @@ async def handle_client_certificate_request(
 async def handle_security_error(
     client: Client, error: SecurityError, uri: AnyURI, owner: Widget
 ) -> None:
-    """Handle a security error from a Gemini request.
+    """Handle a security error from a Gemini/Titan request.
 
     Args:
+        client: The client that contains the trust store.
         error: The security error to handle.
         uri: The URI that caused the security error.
         owner: The widget that owns the request.

--- a/src/rogallo/screens/main/handlers/_glv.py
+++ b/src/rogallo/screens/main/handlers/_glv.py
@@ -1,0 +1,120 @@
+"""Protocol handler code shared between Gemini and Titan."""
+
+##############################################################################
+# Textual imports.
+from textual.widget import Widget
+
+##############################################################################
+# Wasat imports.
+from wasat import AnyURI, Client, ClientCertificate, Response
+
+##############################################################################
+# Local imports.
+from ....document import Document
+from ....messages import ClientCertificatesModified, OpenLocation
+from ....text_decoder import decode_text
+from ...client_certificate import (
+    CertificateData,
+    ClientCertificatePicker,
+    ClientCertificatePickerResult,
+    LocationSpecificClientCertificateMaker,
+)
+
+
+##############################################################################
+async def document(uri: AnyURI, request: OpenLocation, response: Response) -> Document:
+    """Create a Document from a response.
+
+    Args:
+        uri: The URI of the document.
+        request: The request that was made.
+        response: The response that was received.
+
+    Returns:
+        A Document object.
+    """
+    return Document(
+        location=uri,
+        original_location=request.location,
+        content=await decode_text(response),
+        mime_type=response.mime_type,
+        needed_client_certificate=response.client_cert_used,
+        client_certificate=response.client_cert,
+        verification_method=response.verification_method,
+        server_certificate=response.server_cert,
+        avoid_cache=response.client_cert_used,
+        avoid_history=request.avoid_history,
+    )
+
+
+##############################################################################
+async def handle_client_certificate_request(
+    location: AnyURI, request_reason: str, client: Client, owner: Widget
+) -> None:
+    """Handle a request for a client certificate from a Gemini request.
+
+    Args:
+        location: The location making the request.
+        request_reason: The reason for the client certificate request.
+        client: The client to use for the request.
+        owner: The widget that owns the request.
+    """
+
+    decision: ClientCertificatePickerResult = None
+
+    # Check if there are any certificates available to use.
+    if available_certificates := await client.client_cert_store.list_certificates():
+        decision = await owner.app.push_screen_wait(
+            ClientCertificatePicker(location, available_certificates)
+        )
+
+    # Bail if the user backed out.
+    if decision is None:
+        owner.notify("Client certificate request cancelled.", severity="warning")
+        return
+
+    # If the user selected an existing certificate, associate it with the location.
+    if isinstance(decision, ClientCertificate):
+        try:
+            await client.client_cert_store.associate_scope(
+                decision, location.with_path(None).with_query(None)
+            )
+        except (ValueError, RuntimeError) as error:
+            owner.notify(
+                f"Unable to associate client certificate for {location}:\n\n{error}",
+                severity="error",
+                title="Client Certificate Error",
+            )
+            return
+    else:
+        # The user elected to create a new certificate, so show the
+        # certificate creation dialog.
+        certificate_data: CertificateData | None = None
+        if (
+            certificate_data := await owner.app.push_screen_wait(
+                LocationSpecificClientCertificateMaker(location, request_reason)
+            )
+        ) is None:
+            owner.notify("Client certificate creation cancelled.", severity="warning")
+            return
+
+        # If they didn't bail on entering the new details, create the certificate.
+        if certificate_data is not None:
+            try:
+                await client.client_cert_store.create_certificate(**certificate_data)
+            except (ValueError, OSError, RuntimeError) as error:
+                owner.notify(
+                    f"Unable to create client certificate for {location}:\n\n{error}",
+                    severity="error",
+                    title="Client Certificate Error",
+                )
+                return
+
+    # Finally, at this point, we've made *some* sort of change to the
+    # certificate data so flag that up, and then re-request the original
+    # location.
+    owner.post_message(ClientCertificatesModified())
+    owner.post_message(OpenLocation(location, allow_cached=False))
+
+
+### _glv.py ends here

--- a/src/rogallo/screens/main/handlers/_glv.py
+++ b/src/rogallo/screens/main/handlers/_glv.py
@@ -1,6 +1,10 @@
 """Protocol handler code shared between Gemini and Titan."""
 
 ##############################################################################
+# Python imports.
+from collections.abc import Callable
+
+##############################################################################
 # Textual imports.
 from textual.widget import Widget
 
@@ -11,6 +15,7 @@ from wasat import AnyURI, Client, ClientCertificate, Response, SecurityError
 ##############################################################################
 # Local imports.
 from ....document import Document
+from ....input_content import InputContent
 from ....messages import ClientCertificatesModified, OpenLocation
 from ....text_decoder import decode_text
 from ...client_certificate import (
@@ -20,6 +25,12 @@ from ...client_certificate import (
     LocationSpecificClientCertificateMaker,
 )
 from ...security_alert import SecurityAlert
+
+##############################################################################
+type LastInputSetter = Callable[[InputContent | None], None]
+"""Type of a setter for the last input."""
+type LastInputGetter = Callable[[], InputContent | None]
+"""Type of a getter for the last input."""
 
 
 ##############################################################################

--- a/src/rogallo/screens/main/handlers/_glv.py
+++ b/src/rogallo/screens/main/handlers/_glv.py
@@ -6,7 +6,7 @@ from textual.widget import Widget
 
 ##############################################################################
 # Wasat imports.
-from wasat import AnyURI, Client, ClientCertificate, Response
+from wasat import AnyURI, Client, ClientCertificate, Response, SecurityError
 
 ##############################################################################
 # Local imports.
@@ -19,6 +19,7 @@ from ...client_certificate import (
     ClientCertificatePickerResult,
     LocationSpecificClientCertificateMaker,
 )
+from ...security_alert import SecurityAlert
 
 
 ##############################################################################
@@ -115,6 +116,28 @@ async def handle_client_certificate_request(
     # location.
     owner.post_message(ClientCertificatesModified())
     owner.post_message(OpenLocation(location, allow_cached=False))
+
+
+##############################################################################
+async def handle_security_error(
+    client: Client, error: SecurityError, uri: AnyURI, owner: Widget
+) -> None:
+    """Handle a security error from a Gemini request.
+
+    Args:
+        error: The security error to handle.
+        uri: The URI that caused the security error.
+        owner: The widget that owns the request.
+    """
+    if await owner.app.push_screen_wait(SecurityAlert(uri, str(error))):
+        assert client.trust_store is not None
+        await client.trust_store.forget(uri.host, uri.port)
+        owner.post_message(OpenLocation(uri, allow_cached=False))
+        owner.notify(
+            f"Reset the trust status for {uri.host}:{uri.port}",
+            title="Security Alert",
+            severity="warning",
+        )
 
 
 ### _glv.py ends here

--- a/src/rogallo/screens/main/handlers/gemini.py
+++ b/src/rogallo/screens/main/handlers/gemini.py
@@ -1,10 +1,6 @@
 """Provides code for handling a Gemini request."""
 
 ##############################################################################
-# Python imports.
-from collections.abc import Callable
-
-##############################################################################
 # Textual imports.
 from textual.widget import Widget
 
@@ -28,13 +24,13 @@ from ....messages import OpenLocation
 from ....mime_checks import is_displayable_mime_type
 from ...user_input import UserInput
 from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
-from ._glv import document, handle_client_certificate_request, handle_security_error
-
-##############################################################################
-type LastInputSetter = Callable[[InputContent | None], None]
-"""Type of a setter for the last input."""
-type LastInputGetter = Callable[[], InputContent | None]
-"""Type of a getter for the last input."""
+from ._glv import (
+    LastInputGetter,
+    LastInputSetter,
+    document,
+    handle_client_certificate_request,
+    handle_security_error,
+)
 
 
 ##############################################################################

--- a/src/rogallo/screens/main/handlers/gemini.py
+++ b/src/rogallo/screens/main/handlers/gemini.py
@@ -12,7 +12,6 @@ from textual.widget import Widget
 # Wasat imports.
 from wasat import (
     Client,
-    ClientCertificate,
     ConnectionError,
     GeminiURI,
     Response,
@@ -24,96 +23,19 @@ from wasat import (
 ##############################################################################
 # Local imports.
 from ....cache import ContentCache
-from ....document import Document
 from ....input_content import InputContent
-from ....messages import ClientCertificatesModified, OpenLocation
+from ....messages import OpenLocation
 from ....mime_checks import is_displayable_mime_type
-from ....text_decoder import decode_text
-from ...client_certificate import (
-    CertificateData,
-    ClientCertificatePicker,
-    ClientCertificatePickerResult,
-    LocationSpecificClientCertificateMaker,
-)
 from ...security_alert import SecurityAlert
 from ...user_input import UserInput
 from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
+from ._glv import document, handle_client_certificate_request
 
 ##############################################################################
 type LastInputSetter = Callable[[InputContent | None], None]
 """Type of a setter for the last input."""
 type LastInputGetter = Callable[[], InputContent | None]
 """Type of a getter for the last input."""
-
-
-##############################################################################
-async def _handle_client_certificate_request(
-    location: GeminiURI, request_reason: str, client: Client, owner: Widget
-) -> None:
-    """Handle a request for a client certificate from a Gemini request.
-
-    Args:
-        location: The location making the request.
-        request_reason: The reason for the client certificate request.
-        client: The client to use for the request.
-        owner: The widget that owns the request.
-    """
-
-    decision: ClientCertificatePickerResult = None
-
-    # Check if there are any certificates available to use.
-    if available_certificates := await client.client_cert_store.list_certificates():
-        decision = await owner.app.push_screen_wait(
-            ClientCertificatePicker(location, available_certificates)
-        )
-
-    # Bail if the user backed out.
-    if decision is None:
-        owner.notify("Client certificate request cancelled.", severity="warning")
-        return
-
-    # If the user selected an existing certificate, associate it with the location.
-    if isinstance(decision, ClientCertificate):
-        try:
-            await client.client_cert_store.associate_scope(
-                decision, location.with_path(None).with_query(None)
-            )
-        except (ValueError, RuntimeError) as error:
-            owner.notify(
-                f"Unable to associate client certificate for {location}:\n\n{error}",
-                severity="error",
-                title="Client Certificate Error",
-            )
-            return
-    else:
-        # The user elected to create a new certificate, so show the
-        # certificate creation dialog.
-        certificate_data: CertificateData | None = None
-        if (
-            certificate_data := await owner.app.push_screen_wait(
-                LocationSpecificClientCertificateMaker(location, request_reason)
-            )
-        ) is None:
-            owner.notify("Client certificate creation cancelled.", severity="warning")
-            return
-
-        # If they didn't bail on entering the new details, create the certificate.
-        if certificate_data is not None:
-            try:
-                await client.client_cert_store.create_certificate(**certificate_data)
-            except (ValueError, OSError, RuntimeError) as error:
-                owner.notify(
-                    f"Unable to create client certificate for {location}:\n\n{error}",
-                    severity="error",
-                    title="Client Certificate Error",
-                )
-                return
-
-    # Finally, at this point, we've made *some* sort of change to the
-    # certificate data so flag that up, and then re-request the original
-    # location.
-    owner.post_message(ClientCertificatesModified())
-    owner.post_message(OpenLocation(location, allow_cached=False))
 
 
 ##############################################################################
@@ -199,7 +121,7 @@ async def _handle_response(
 
     # Handle a request for a client certificate.
     if response.status.is_client_certificate_required:
-        await _handle_client_certificate_request(
+        await handle_client_certificate_request(
             uri, response.meta.strip(), client, owner
         )
         return
@@ -221,20 +143,7 @@ async def _handle_response(
     if is_displayable_mime_type(response.mime_type):
         owner.post_message(
             OpenDocument(
-                cache.add_document(
-                    Document(
-                        location=uri,
-                        original_location=request.location,
-                        content=await decode_text(response),
-                        mime_type=response.mime_type,
-                        needed_client_certificate=response.client_cert_used,
-                        client_certificate=response.client_cert,
-                        verification_method=response.verification_method,
-                        server_certificate=response.server_cert,
-                        avoid_cache=response.client_cert_used,
-                        avoid_history=request.avoid_history,
-                    )
-                ),
+                cache.add_document(await document(uri, request, response)),
                 from_history=request.from_history,
             )
         )

--- a/src/rogallo/screens/main/handlers/gemini.py
+++ b/src/rogallo/screens/main/handlers/gemini.py
@@ -26,10 +26,9 @@ from ....cache import ContentCache
 from ....input_content import InputContent
 from ....messages import OpenLocation
 from ....mime_checks import is_displayable_mime_type
-from ...security_alert import SecurityAlert
 from ...user_input import UserInput
 from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
-from ._glv import document, handle_client_certificate_request
+from ._glv import document, handle_client_certificate_request, handle_security_error
 
 ##############################################################################
 type LastInputSetter = Callable[[InputContent | None], None]
@@ -152,28 +151,6 @@ async def _handle_response(
 
 
 ##############################################################################
-async def _handle_security_error(
-    client: Client, error: SecurityError, uri: GeminiURI, owner: Widget
-) -> None:
-    """Handle a security error from a Gemini request.
-
-    Args:
-        error: The security error to handle.
-        uri: The URI that caused the security error.
-        owner: The widget that owns the request.
-    """
-    if await owner.app.push_screen_wait(SecurityAlert(uri, str(error))):
-        assert client.trust_store is not None
-        await client.trust_store.forget(uri.host, uri.port)
-        owner.post_message(OpenLocation(uri, allow_cached=False))
-        owner.notify(
-            f"Reset the trust status for {uri.host}:{uri.port}",
-            title="Security Alert",
-            severity="warning",
-        )
-
-
-##############################################################################
 async def handle_gemini_request(
     request: OpenLocation,
     owner: Widget,
@@ -226,7 +203,7 @@ async def handle_gemini_request(
             title="Connection Error",
         )
     except SecurityError as error:
-        await _handle_security_error(client, error, uri, owner)
+        await handle_security_error(client, error, uri, owner)
 
 
 ### gemini.py ends here

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -152,7 +152,13 @@ async def handle_titan_request(
                 token=upload.token,
             ) as response:
                 await _handle_response(response, request, client, owner)
-        except ConnectionError as error:
+        except (
+            URIError,
+            ConnectionError,
+            ProtocolError,
+            RedirectError,
+            TypeError,
+        ) as error:
             owner.notify(
                 f"Error loading {uri}:\n\n{error}",
                 severity="error",

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -20,17 +20,29 @@ from wasat import (
 
 ##############################################################################
 # Local imports.
+from ....input_content import InputContent
 from ....messages import OpenLocation
 from ....mime_checks import is_displayable_mime_type
 from ....text_decoder import decode_text
 from ...user_upload import UserUpload
 from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
-from ._glv import document, handle_client_certificate_request, handle_security_error
+from ._glv import (
+    LastInputGetter,
+    LastInputSetter,
+    document,
+    handle_client_certificate_request,
+    handle_security_error,
+)
 
 
 ##############################################################################
 async def _handle_response(
-    response: Response, request: OpenLocation, client: Client, owner: Widget
+    response: Response,
+    request: OpenLocation,
+    client: Client,
+    owner: Widget,
+    set_last_input: LastInputSetter,
+    savable_input: InputContent | None = None,
 ) -> None:
     """Handle a Titan response.
 
@@ -39,12 +51,14 @@ async def _handle_response(
         request: The request that was made.
         client: The Titan client to use for any follow-up requests.
         owner: The widget that owns the request.
+        set_last_input: A function to set the last input from the user.
     """
     uri = response.uri or response.requested_uri or request.location
     assert isinstance(uri, GeminiURI | TitanURI)
 
     # Handle a request for a client certificate.
     if response.status.is_client_certificate_required:
+        set_last_input(savable_input)
         await handle_client_certificate_request(
             uri, response.meta.strip(), client, owner
         )
@@ -52,12 +66,16 @@ async def _handle_response(
 
     # Handle any other non-successful response.
     if not response.status.is_success:
+        set_last_input(savable_input)
         owner.notify(
             f"Error loading {uri}:\n\n{response.status.value} {response.status.name}\n{response.meta}",
             severity="error",
             title="Request Error",
         )
         return
+
+    # Clear out any saved input.
+    set_last_input(None)
 
     # Handle a successful response.
     if is_displayable_mime_type(response.mime_type):
@@ -116,7 +134,11 @@ async def _get_raw_content_to_edit(
 
 ##############################################################################
 async def handle_titan_request(
-    request: OpenLocation, owner: Widget, client: Client
+    request: OpenLocation,
+    owner: Widget,
+    client: Client,
+    set_last_input: LastInputSetter,
+    get_last_input: LastInputGetter,
 ) -> None:
     """Handle a Titan request.
 
@@ -129,18 +151,31 @@ async def handle_titan_request(
     uri = request.location
     assert isinstance(uri, TitanURI)
 
+    # Set up the initial input. If there is a last input that matches the
+    # current request, use that as the initial input.
+    initial_input = ""
+    if ((last_input := get_last_input()) is not None) and last_input == InputContent(
+        location=uri, prompt=""
+    ):
+        initial_input = last_input.content
+
     # If it's a Titan request that is a request to edit existing content,
-    # get the existing content first.
-    raw_content = ""
+    # get the existing content before edit, and also override any saved
+    # content from a previous error.
     if uri.is_edit:
         if (
             raw_from_server := await _get_raw_content_to_edit(uri, client, owner)
         ) is None:
             return
-        raw_content = raw_from_server
+        initial_input = raw_from_server
 
     # Prompt the user for what they want to upload, and then upload it.
-    if upload := await owner.app.push_screen_wait(UserUpload(uri, raw_content)):
+    if upload := await owner.app.push_screen_wait(UserUpload(uri, initial_input)):
+        savable_input = (
+            InputContent(location=uri, prompt="", content=upload.data)
+            if isinstance(upload.data, str)
+            else None
+        )
         try:
             async with await client.upload(
                 uri=uri,
@@ -148,7 +183,9 @@ async def handle_titan_request(
                 mime=upload.mime_type,
                 token=upload.token,
             ) as response:
-                await _handle_response(response, request, client, owner)
+                await _handle_response(
+                    response, request, client, owner, set_last_input, savable_input
+                )
         except (
             URIError,
             ConnectionError,
@@ -156,6 +193,8 @@ async def handle_titan_request(
             RedirectError,
             TypeError,
         ) as error:
+            if savable_input:
+                set_last_input(savable_input)
             owner.notify(
                 f"Error loading {uri}:\n\n{error}",
                 severity="error",

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -24,7 +24,7 @@ from ....mime_checks import is_displayable_mime_type
 from ....text_decoder import decode_text
 from ...user_upload import UserUpload
 from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
-from ._glv import document, handle_client_certificate_request
+from ._glv import document, handle_client_certificate_request, handle_security_error
 
 
 ##############################################################################
@@ -109,11 +109,7 @@ async def _get_raw_content_to_edit(
             title="Connection Error",
         )
     except SecurityError as error:
-        owner.notify(
-            f"Error loading {uri}:\n\n{error}",
-            severity="error",
-            title="Security Error",
-        )
+        await handle_security_error(client, error, uri, owner)
     return None
 
 
@@ -165,11 +161,7 @@ async def handle_titan_request(
                 title="Connection Error",
             )
         except SecurityError as error:
-            owner.notify(
-                f"Error loading {uri}:\n\n{error}",
-                severity="error",
-                title="Security Error",
-            )
+            await handle_security_error(client, error, uri, owner)
 
 
 ### titan.py ends here

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -31,7 +31,10 @@ async def _handle_response(
     uri = response.uri or response.requested_uri or request.location
     assert isinstance(uri, GeminiURI | TitanURI)
 
-    # Handle any other non-successful response.
+    # TODO: Should I still handle a `is_client_certificate_required`
+    # response here?
+
+    # Handle any non-successful response.
     if not response.status.is_success:
         owner.notify(
             f"Error loading {uri}:\n\n{response.status.value} {response.status.name}\n{response.meta}",

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -11,6 +11,7 @@ from wasat import Client, TitanURI
 ##############################################################################
 # Local imports.
 from ....messages import OpenLocation
+from ...user_upload import UserUpload
 
 
 ##############################################################################
@@ -28,7 +29,8 @@ async def handle_titan_request(
     uri = request.location
     assert isinstance(uri, TitanURI)
 
-    owner.notify(f"TODO: Handling Titan request for {request.location}")
+    if upload := await owner.app.push_screen_wait(UserUpload(uri)):
+        owner.notify(f"TODO: Perform the upload {upload!r}")
 
 
 ### titan.py ends here

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -6,12 +6,60 @@ from textual.widget import Widget
 
 ##############################################################################
 # Wasat imports.
-from wasat import Client, TitanURI
+from wasat import Client, GeminiURI, Response, TitanURI
 
 ##############################################################################
 # Local imports.
+from ....document import Document
 from ....messages import OpenLocation
+from ....mime_checks import is_displayable_mime_type
+from ....text_decoder import decode_text
 from ...user_upload import UserUpload
+from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
+
+
+##############################################################################
+async def _handle_response(
+    response: Response, request: OpenLocation, owner: Widget
+) -> None:
+    """Handle a Titan response.
+
+    Args:
+        response: The response to handle.
+        owner: The widget that owns the request.
+    """
+    uri = response.uri or response.requested_uri or request.location
+    assert isinstance(uri, GeminiURI | TitanURI)
+
+    # Handle any other non-successful response.
+    if not response.status.is_success:
+        owner.notify(
+            f"Error loading {uri}:\n\n{response.status.value} {response.status.name}\n{response.meta}",
+            severity="error",
+            title="Request Error",
+        )
+        return
+
+    # Handle a successful response.
+    if is_displayable_mime_type(response.mime_type):
+        owner.post_message(
+            OpenDocument(
+                Document(
+                    location=uri,
+                    original_location=request.location,
+                    content=await decode_text(response),
+                    mime_type=response.mime_type,
+                    needed_client_certificate=response.client_cert_used,
+                    client_certificate=response.client_cert,
+                    verification_method=response.verification_method,
+                    server_certificate=response.server_cert,
+                    avoid_cache=response.client_cert_used,
+                    avoid_history=request.avoid_history,
+                )
+            )
+        )
+    else:
+        owner.post_message(OpenUnsupportedMIMEType(uri, response.mime_type))
 
 
 ##############################################################################
@@ -30,7 +78,13 @@ async def handle_titan_request(
     assert isinstance(uri, TitanURI)
 
     if upload := await owner.app.push_screen_wait(UserUpload(uri)):
-        owner.notify(f"TODO: Perform the upload {upload!r}")
+        async with await client.upload(
+            uri=uri,
+            data=upload.data,
+            mime=upload.mime_type,
+            token=upload.token,
+        ) as response:
+            await _handle_response(response, request, owner)
 
 
 ### titan.py ends here

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -8,6 +8,7 @@ from textual.widget import Widget
 # Wasat imports.
 from wasat import (
     Client,
+    ConnectionError,
     GeminiURI,
     ProtocolError,
     RedirectError,

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -19,31 +19,37 @@ from wasat import (
 
 ##############################################################################
 # Local imports.
-from ....document import Document
 from ....messages import OpenLocation
 from ....mime_checks import is_displayable_mime_type
 from ....text_decoder import decode_text
 from ...user_upload import UserUpload
 from ..local_messages import OpenDocument, OpenUnsupportedMIMEType
+from ._glv import document, handle_client_certificate_request
 
 
 ##############################################################################
 async def _handle_response(
-    response: Response, request: OpenLocation, owner: Widget
+    response: Response, request: OpenLocation, client: Client, owner: Widget
 ) -> None:
     """Handle a Titan response.
 
     Args:
         response: The response to handle.
+        request: The request that was made.
+        client: The Titan client to use for any follow-up requests.
         owner: The widget that owns the request.
     """
     uri = response.uri or response.requested_uri or request.location
     assert isinstance(uri, GeminiURI | TitanURI)
 
-    # TODO: Should I still handle a `is_client_certificate_required`
-    # response here?
+    # Handle a request for a client certificate.
+    if response.status.is_client_certificate_required:
+        await handle_client_certificate_request(
+            uri, response.meta.strip(), client, owner
+        )
+        return
 
-    # Handle any non-successful response.
+    # Handle any other non-successful response.
     if not response.status.is_success:
         owner.notify(
             f"Error loading {uri}:\n\n{response.status.value} {response.status.name}\n{response.meta}",
@@ -56,18 +62,8 @@ async def _handle_response(
     if is_displayable_mime_type(response.mime_type):
         owner.post_message(
             OpenDocument(
-                Document(
-                    location=uri,
-                    original_location=request.location,
-                    content=await decode_text(response),
-                    mime_type=response.mime_type,
-                    needed_client_certificate=response.client_cert_used,
-                    client_certificate=response.client_cert,
-                    verification_method=response.verification_method,
-                    server_certificate=response.server_cert,
-                    avoid_cache=response.client_cert_used,
-                    avoid_history=request.avoid_history,
-                )
+                await document(uri, request, response),
+                from_history=request.from_history,
             )
         )
     else:
@@ -155,7 +151,7 @@ async def handle_titan_request(
                 mime=upload.mime_type,
                 token=upload.token,
             ) as response:
-                await _handle_response(response, request, owner)
+                await _handle_response(response, request, client, owner)
         except ConnectionError as error:
             owner.notify(
                 f"Error loading {uri}:\n\n{error}",

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -6,7 +6,16 @@ from textual.widget import Widget
 
 ##############################################################################
 # Wasat imports.
-from wasat import Client, GeminiURI, Response, SecurityError, TitanURI
+from wasat import (
+    Client,
+    GeminiURI,
+    ProtocolError,
+    RedirectError,
+    Response,
+    SecurityError,
+    TitanURI,
+    URIError,
+)
 
 ##############################################################################
 # Local imports.
@@ -66,6 +75,53 @@ async def _handle_response(
 
 
 ##############################################################################
+async def _get_raw_content_to_edit(
+    uri: TitanURI, client: Client, owner: Widget
+) -> str | None:
+    """Get the raw content of a Titan document to edit.
+
+    Args:
+        uri: The URI of the document to edit.
+        client: The Titan client to use for the request.
+        owner: The widget that owns the request.
+
+    Returns:
+        The raw content of the document, or `None` if there was an error.
+    """
+    try:
+        async with await client.edit(uri) as response:
+            if not response.status.is_success:
+                owner.notify(
+                    f"Error loading {uri}:\n\n{response.status.value} {response.status.name}\n{response.meta}",
+                    severity="error",
+                    title="Request Error",
+                )
+                return None
+            return await decode_text(response)
+    except (
+        URIError,
+        ConnectionError,
+        ProtocolError,
+        RedirectError,
+        ValueError,
+        OSError,
+        RuntimeError,
+    ) as error:
+        owner.notify(
+            f"Error loading {uri}:\n\n{error}",
+            severity="error",
+            title="Connection Error",
+        )
+    except SecurityError as error:
+        owner.notify(
+            f"Error loading {uri}:\n\n{error}",
+            severity="error",
+            title="Security Error",
+        )
+    return None
+
+
+##############################################################################
 async def handle_titan_request(
     request: OpenLocation, owner: Widget, client: Client
 ) -> None:
@@ -80,7 +136,18 @@ async def handle_titan_request(
     uri = request.location
     assert isinstance(uri, TitanURI)
 
-    if upload := await owner.app.push_screen_wait(UserUpload(uri)):
+    # If it's a Titan request that is a request to edit existing content,
+    # get the existing content first.
+    raw_content = ""
+    if uri.is_edit:
+        if (
+            raw_from_server := await _get_raw_content_to_edit(uri, client, owner)
+        ) is None:
+            return
+        raw_content = raw_from_server
+
+    # Prompt the user for what they want to upload, and then upload it.
+    if upload := await owner.app.push_screen_wait(UserUpload(uri, raw_content)):
         try:
             async with await client.upload(
                 uri=uri,

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -6,7 +6,7 @@ from textual.widget import Widget
 
 ##############################################################################
 # Wasat imports.
-from wasat import Client, GeminiURI, Response, TitanURI
+from wasat import Client, GeminiURI, Response, SecurityError, TitanURI
 
 ##############################################################################
 # Local imports.
@@ -78,13 +78,26 @@ async def handle_titan_request(
     assert isinstance(uri, TitanURI)
 
     if upload := await owner.app.push_screen_wait(UserUpload(uri)):
-        async with await client.upload(
-            uri=uri,
-            data=upload.data,
-            mime=upload.mime_type,
-            token=upload.token,
-        ) as response:
-            await _handle_response(response, request, owner)
+        try:
+            async with await client.upload(
+                uri=uri,
+                data=upload.data,
+                mime=upload.mime_type,
+                token=upload.token,
+            ) as response:
+                await _handle_response(response, request, owner)
+        except ConnectionError as error:
+            owner.notify(
+                f"Error loading {uri}:\n\n{error}",
+                severity="error",
+                title="Connection Error",
+            )
+        except SecurityError as error:
+            owner.notify(
+                f"Error loading {uri}:\n\n{error}",
+                severity="error",
+                title="Security Error",
+            )
 
 
 ### titan.py ends here

--- a/src/rogallo/screens/main/handlers/titan.py
+++ b/src/rogallo/screens/main/handlers/titan.py
@@ -1,0 +1,34 @@
+"""Provides code for handling a Titan request."""
+
+##############################################################################
+# Textual imports.
+from textual.widget import Widget
+
+##############################################################################
+# Wasat imports.
+from wasat import Client, TitanURI
+
+##############################################################################
+# Local imports.
+from ....messages import OpenLocation
+
+
+##############################################################################
+async def handle_titan_request(
+    request: OpenLocation, owner: Widget, client: Client
+) -> None:
+    """Handle a Titan request.
+
+    Args:
+        request: The request to handle.
+        owner: The widget that owns the request.
+        client: The Titan client to use for the request.
+    """
+
+    uri = request.location
+    assert isinstance(uri, TitanURI)
+
+    owner.notify(f"TODO: Handling Titan request for {request.location}")
+
+
+### titan.py ends here

--- a/src/rogallo/screens/main/request_builder.py
+++ b/src/rogallo/screens/main/request_builder.py
@@ -99,6 +99,8 @@ def build_request(
             request=message,
             client=clients.gemini,
             owner=owner,
+            set_last_input=set_last_input,
+            get_last_input=get_last_input,
         )
     return None
 

--- a/src/rogallo/screens/main/request_builder.py
+++ b/src/rogallo/screens/main/request_builder.py
@@ -26,7 +26,7 @@ from textual.widget import Widget
 
 ##############################################################################
 # Wasat imports.
-from wasat import GeminiURI
+from wasat import GeminiURI, TitanURI
 
 ##############################################################################
 # Local imports.
@@ -42,6 +42,7 @@ from .handlers import (
     handle_gopher_request,
     handle_nex_request,
     handle_spartan_request,
+    handle_titan_request,
 )
 
 
@@ -92,6 +93,12 @@ def build_request(
             client=clients.nex,
             owner=owner,
             cache=cache,
+        )
+    if isinstance(message.location, TitanURI):
+        return handle_titan_request(
+            request=message,
+            client=clients.gemini,
+            owner=owner,
         )
     return None
 

--- a/src/rogallo/screens/main/uri_resolver.py
+++ b/src/rogallo/screens/main/uri_resolver.py
@@ -22,7 +22,7 @@ from sybaritic import URIError as SpartanURIError
 
 ##############################################################################
 # Wasat imports
-from wasat import GeminiURI
+from wasat import GeminiURI, TitanURI
 from wasat import URIError as GeminiURIError
 
 ##############################################################################
@@ -54,6 +54,7 @@ def uri_resolver(
     # Work through the supported URI types.
     for uri_type, uri_error in (
         (GeminiURI, GeminiURIError),
+        (TitanURI, GeminiURIError),
         (FingerURI, FingerURIError),
         (GopherURI, GopherURIError),
         (SpartanURI, SpartanURIError),

--- a/src/rogallo/screens/user_input.py
+++ b/src/rogallo/screens/user_input.py
@@ -1,13 +1,6 @@
 """Provides a modal screen for getting user input."""
 
 ##############################################################################
-# Python imports.
-from os import getenv
-from pathlib import Path
-from subprocess import run
-from tempfile import NamedTemporaryFile
-
-##############################################################################
 # Sybaritic imports.
 from sybaritic import SpartanURI
 
@@ -26,8 +19,7 @@ from wasat import GeminiURI
 
 ##############################################################################
 # Local imports.
-from ..data import load_configuration
-from ..types import DEFAULT_GEMINI_EXTENSION
+from ..editor import edit_externally, external_editor
 
 
 ##############################################################################
@@ -122,20 +114,10 @@ class UserInput(ModalScreen[str | None]):
             and self._location.with_query(self._current_text).is_too_long
         )
 
-    @property
-    def _external_editor(self) -> str | None:
-        """The external editor to use, if any."""
-        return (
-            load_configuration().external_editor
-            or getenv("VISUAL")
-            or getenv("EDITOR")
-            or None
-        )
-
     def _update_subtitle(self) -> None:
         """Update the subtitle of the input area."""
         footer = "F2: Submit"
-        if bool(self._external_editor):
+        if external_editor():
             footer += " | F3: $EDITOR"
         if not self._input.text:
             self._input.border_subtitle = footer
@@ -167,20 +149,7 @@ class UserInput(ModalScreen[str | None]):
 
     def action_edit_externally(self) -> None:
         """Edit the input in an external editor."""
-        if not (editor := self._external_editor):
-            return
-        with NamedTemporaryFile(
-            mode="w+", delete=False, encoding="utf-8", suffix=DEFAULT_GEMINI_EXTENSION
-        ) as temp_file:
-            user_input = Path(temp_file.name)
-            temp_file.write(self._current_text)
-            temp_file.close()
-            try:
-                with self.app.suspend():
-                    run((editor, user_input))
-                self._input.text = user_input.read_text(encoding="utf-8")
-            finally:
-                user_input.unlink(missing_ok=True)
+        self._input.text = edit_externally(self.app, self._input.text)
 
 
 ### user_input.py ends here

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -6,7 +6,10 @@ This screen is intended to be used for Titan uploads.
 ##############################################################################
 # Python imports.
 from mimetypes import guess_type
+from os import getenv
 from pathlib import Path
+from subprocess import run
+from tempfile import NamedTemporaryFile
 from typing import NamedTuple
 
 ##############################################################################
@@ -32,7 +35,9 @@ from wasat import TitanURI
 
 ##############################################################################
 # Local imports.
+from ..data import load_configuration
 from ..presentation import short_location
+from ..types import DEFAULT_GEMINI_EXTENSION
 
 
 ##############################################################################
@@ -107,8 +112,9 @@ class UserUpload(ModalScreen[UploadData | None]):
 
     BINDINGS = [
         ("f2", "upload"),
-        ("f3", "prepare_text"),
-        ("f4", "prepare_file"),
+        ("f3", "edit_externally"),
+        ("ctrl+t", "prepare_text"),
+        ("ctrl+f", "prepare_file"),
         ("escape", "cancel"),
     ]
 
@@ -135,18 +141,30 @@ class UserUpload(ModalScreen[UploadData | None]):
         self._selected_file: Path | None = None
         """The selected file to upload."""
 
+    @property
+    def _external_editor(self) -> str | None:
+        """The external editor to use, if any."""
+        return (
+            load_configuration().external_editor
+            or getenv("VISUAL")
+            or getenv("EDITOR")
+            or None
+        )
+
     def compose(self) -> ComposeResult:
         """Compose the screen."""
         with VerticalGroup() as dialog:
             dialog.border_title = f"Upload to {self._location}"
             dialog.border_subtitle = "Titan"
             with TabbedContent():
-                with TabPane("Text [$accent]\\[f3][/]", id="text"):
+                with TabPane("Text [$accent]\\[^t][/]", id="text"):
                     yield TextArea(
                         highlight_cursor_line=False,
                         placeholder="Enter text to upload...",
                     )
-                with TabPane("File [$accent]\\[f4][/]", id="file"):
+                    if self._external_editor:
+                        yield Label("[$accent]\\[f3][/] for $EDITOR")
+                with TabPane("File [$accent]\\[^f][/]", id="file"):
                     yield Button("Select file...", id="select-file")
                     yield Label("Selected file:", classes="--gap-above --title")
                     yield Label("<none>", id="selected-file", classes="--empty")
@@ -216,6 +234,26 @@ class UserUpload(ModalScreen[UploadData | None]):
     def action_cancel(self) -> None:
         """Cancel the upload."""
         self.dismiss(None)
+
+    def action_edit_externally(self) -> None:
+        """Edit the input in an external editor."""
+        if not (
+            (editor := self._external_editor) and self._text_or_file.active == "text"
+        ):
+            return
+        with NamedTemporaryFile(
+            mode="w+", delete=False, encoding="utf-8", suffix=DEFAULT_GEMINI_EXTENSION
+        ) as temp_file:
+            user_input = Path(temp_file.name)
+            temp_file.write(self._text.text)
+            temp_file.close()
+            try:
+                with self.app.suspend():
+                    run((editor, user_input))
+                self._text.text = user_input.read_text(encoding="utf-8")
+                self._text.focus()
+            finally:
+                user_input.unlink(missing_ok=True)
 
 
 ### user_upload.py ends here

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -197,6 +197,7 @@ class UserUpload(ModalScreen[UploadData | None]):
             self.dismiss(
                 UploadData(
                     data=self._text.text,
+                    mime_type="text/plain",
                     token=self._token.value.strip() or None,
                 )
             )

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -5,6 +5,7 @@ This screen is intended to be used for Titan uploads.
 
 ##############################################################################
 # Python imports.
+from mimetypes import guess_type
 from pathlib import Path
 from typing import NamedTuple
 
@@ -186,6 +187,8 @@ class UserUpload(ModalScreen[UploadData | None]):
             self._selected_file = selected_file
             self._selected_file_display.update(short_location(selected_file))
             self._selected_file_display.remove_class("--empty")
+            mime_type, _ = guess_type(self._selected_file)
+            self._mime_type.value = mime_type or "application/octet-stream"
 
     @on(Button.Pressed, "#upload")
     def action_upload(self) -> None:

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -63,19 +63,20 @@ class UserUpload(ModalScreen[UploadData | None]):
         &> VerticalGroup {
             height: 60vh;
             width: 60vw;
-            padding: 1 2;
             background: $panel;
             border: panel $border;
 
             TabbedContent {
                 height: 1fr;
+                margin: 1;
             }
 
             #token-input {
                 align: left middle;
                 width: 1fr;
+                padding: 0 1 0 2;
                 height: auto;
-                margin-top: 1;
+                border-top: solid $border;
                 Input {
                     width: 1fr;
                 }
@@ -89,9 +90,15 @@ class UserUpload(ModalScreen[UploadData | None]):
                 align: right middle;
                 width: 100%;
                 height: auto;
-                padding-top: 1;
+                padding: 1 1 0 0;
                 Button {
                     margin-right: 1;
+                }
+            }
+
+            #file {
+                Button, Label {
+                    margin: 0 0 1 1;
                 }
             }
 
@@ -103,10 +110,6 @@ class UserUpload(ModalScreen[UploadData | None]):
 
             .--empty {
                 color: $text-muted;
-            }
-
-            .--gap-above {
-                margin-top: 1;
             }
 
             .--title {
@@ -172,9 +175,9 @@ class UserUpload(ModalScreen[UploadData | None]):
                         yield Label("[$accent]\\[f3][/] for $EDITOR", id="editor-help")
                 with TabPane("File [$accent]\\[^f][/]", id="file"):
                     yield Button("Select file...", id="select-file")
-                    yield Label("Selected file:", classes="--gap-above --title")
+                    yield Label("Selected file:", classes="--title")
                     yield Label("<none>", id="selected-file", classes="--empty")
-                    yield Label("Mime type:", classes="--gap-above --title")
+                    yield Label("Mime type:", classes="--title")
                     yield Input(
                         placeholder="Enter MIME type (e.g. text/plain)", id="mime-type"
                     )

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -1,0 +1,216 @@
+"""Provides a modal screen for uploading text or a file.
+
+This screen is intended to be used for Titan uploads.
+"""
+
+##############################################################################
+# Python imports.
+from pathlib import Path
+from typing import NamedTuple
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import HorizontalGroup, VerticalGroup
+from textual.getters import query_one
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, TabbedContent, TabPane, TextArea
+
+##############################################################################
+# Textual enhanced imports.
+from textual_enhanced.tools import add_key
+
+##############################################################################
+# Textual FSPicker imports.
+from textual_fspicker import FileOpen
+
+##############################################################################
+# Wasat imports.
+from wasat import TitanURI
+
+##############################################################################
+# Local imports.
+from ..presentation import short_location
+
+
+##############################################################################
+class UploadData(NamedTuple):
+    """The data for uploading."""
+
+    data: str | Path
+    """The data to upload."""
+    mime_type: str | None = None
+    """The MIME type of the data."""
+    token: str | None = None
+    """The token to use for the upload, if any."""
+
+
+##############################################################################
+class UserUpload(ModalScreen[UploadData | None]):
+    """A modal screen to get input from the user."""
+
+    CSS = """
+    UserUpload {
+        align: center middle;
+
+        &> VerticalGroup {
+            height: 60vh;
+            width: 60vw;
+            padding: 1 2;
+            background: $panel;
+            border: panel $border;
+
+            TabbedContent {
+                height: 1fr;
+            }
+
+            #token-input {
+                align: left middle;
+                width: 1fr;
+                height: auto;
+                margin-top: 1;
+                Input {
+                    width: 1fr;
+                }
+                Label {
+                   height: 3;
+                   content-align: center middle;
+                }
+            }
+
+            #buttons {
+                align: right middle;
+                width: 100%;
+                height: auto;
+                padding-top: 1;
+                Button {
+                    margin-right: 1;
+                }
+            }
+
+            .--empty {
+                color: $text-muted;
+            }
+
+            .--gap-above {
+                margin-top: 1;
+            }
+            .--title {
+                color: $accent;
+            }
+        }
+    }
+    """
+
+    BINDINGS = [
+        ("f2", "upload"),
+        ("f3", "prepare_text"),
+        ("f4", "prepare_file"),
+        ("escape", "cancel"),
+    ]
+
+    _text_or_file = query_one(TabbedContent)
+    """The tabbed content widget for text or file."""
+    _selected_file_display = query_one("#selected-file", Label)
+    """The label displaying the selected file."""
+    _text = query_one(TextArea)
+    """The user's input text."""
+    _mime_type = query_one("#mime-type", Input)
+    """The mime type input."""
+    _token = query_one("#token", Input)
+    """The token input."""
+
+    def __init__(self, location: TitanURI) -> None:
+        """Initialise the screen.
+
+        Args:
+            location: The location to upload to.
+        """
+        super().__init__()
+        self._location = location
+        """The location to upload to."""
+        self._selected_file: Path | None = None
+        """The selected file to upload."""
+
+    def compose(self) -> ComposeResult:
+        """Compose the screen."""
+        with VerticalGroup() as dialog:
+            dialog.border_title = f"Upload to {self._location}"
+            dialog.border_subtitle = "Titan"
+            with TabbedContent():
+                with TabPane("Text [$accent]\\[F3][/]", id="text"):
+                    yield TextArea(
+                        highlight_cursor_line=False,
+                        placeholder="Enter text to upload...",
+                    )
+                with TabPane("File [$accent]\\[F4][/]", id="file"):
+                    yield Button("Select file...", id="select-file")
+                    yield Label("Selected file:", classes="--gap-above --title")
+                    yield Label("<none>", id="selected-file", classes="--empty")
+                    yield Label("Mime type:", classes="--gap-above --title")
+                    yield Input(
+                        placeholder="Enter MIME type (e.g. text/plain)", id="mime-type"
+                    )
+            with HorizontalGroup(id="token-input"):
+                yield Label("Token:", classes="--title")
+                yield Input(placeholder="Enter token (optional)", id="token")
+            with HorizontalGroup(id="buttons"):
+                yield Button(add_key("Upload", "F2", self), id="upload")
+                yield Button(add_key("Cancel", "Esc", self), id="cancel")
+
+    def action_prepare_file(self) -> None:
+        """Switch to the file tab."""
+        self.screen.focused = self._text_or_file
+        self._text_or_file.active = "file"
+
+    def action_prepare_text(self) -> None:
+        """Switch to the text tab."""
+        self.screen.focused = self._text_or_file
+        self._text_or_file.active = "text"
+
+    @on(Button.Pressed, "#select-file")
+    async def _select_file(self) -> None:
+        """Select a file to upload."""
+        start_at = Path(".")
+        if self._selected_file is not None and self._selected_file.parent.is_dir():
+            start_at = self._selected_file.parent
+        if selected_file := await self.app.push_screen_wait(
+            FileOpen(
+                start_at,
+                title="Select a file to upload",
+                open_button="Select",
+                cancel_button=add_key("Cancel", "Esc", self),
+            )
+        ):
+            self._selected_file = selected_file
+            self._selected_file_display.update(short_location(selected_file))
+            self._selected_file_display.remove_class("--empty")
+
+    @on(Button.Pressed, "#upload")
+    def action_upload(self) -> None:
+        """Upload the data."""
+        if self._text_or_file.active == "text":
+            self.dismiss(
+                UploadData(
+                    data=self._text.text,
+                    token=self._token.value.strip() or None,
+                )
+            )
+        elif self._text_or_file.active == "file" and self._selected_file is not None:
+            self.dismiss(
+                UploadData(
+                    data=self._selected_file,
+                    mime_type=self._mime_type.value.strip()
+                    or "application/octet-stream",
+                    token=self._token.value.strip() or None,
+                )
+            )
+
+    @on(Button.Pressed, "#cancel")
+    def action_cancel(self) -> None:
+        """Cancel the upload."""
+        self.dismiss(None)
+
+
+### user_upload.py ends here

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -5,7 +5,7 @@ This screen is intended to be used for Titan uploads.
 
 ##############################################################################
 # Python imports.
-from mimetypes import guess_type
+from mimetypes import guess_type, types_map
 from os import getenv
 from pathlib import Path
 from subprocess import run
@@ -19,6 +19,7 @@ from textual.app import ComposeResult
 from textual.containers import HorizontalGroup, VerticalGroup
 from textual.getters import query_one
 from textual.screen import ModalScreen
+from textual.suggester import SuggestFromList
 from textual.widgets import Button, Input, Label, TabbedContent, TabPane, TextArea
 
 ##############################################################################
@@ -179,7 +180,9 @@ class UserUpload(ModalScreen[UploadData | None]):
                     yield Label("<none>", id="selected-file", classes="--empty")
                     yield Label("Mime type:", classes="--title")
                     yield Input(
-                        placeholder="Enter MIME type (e.g. text/plain)", id="mime-type"
+                        placeholder="Enter MIME type (e.g. text/plain)",
+                        id="mime-type",
+                        suggester=SuggestFromList(sorted(types_map.values())),
                     )
             with HorizontalGroup(id="token-input"):
                 yield Label("Token:", classes="--title")

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -6,10 +6,7 @@ This screen is intended to be used for Titan uploads.
 ##############################################################################
 # Python imports.
 from mimetypes import guess_type, types_map
-from os import getenv
 from pathlib import Path
-from subprocess import run
-from tempfile import NamedTemporaryFile
 from typing import NamedTuple
 
 ##############################################################################
@@ -36,9 +33,8 @@ from wasat import TitanURI
 
 ##############################################################################
 # Local imports.
-from ..data import load_configuration
+from ..editor import edit_externally, external_editor
 from ..presentation import short_location
-from ..types import DEFAULT_GEMINI_EXTENSION
 
 
 ##############################################################################
@@ -151,16 +147,6 @@ class UserUpload(ModalScreen[UploadData | None]):
         self._selected_file: Path | None = None
         """The selected file to upload."""
 
-    @property
-    def _external_editor(self) -> str | None:
-        """The external editor to use, if any."""
-        return (
-            load_configuration().external_editor
-            or getenv("VISUAL")
-            or getenv("EDITOR")
-            or None
-        )
-
     def compose(self) -> ComposeResult:
         """Compose the screen."""
         with VerticalGroup() as dialog:
@@ -172,7 +158,7 @@ class UserUpload(ModalScreen[UploadData | None]):
                         highlight_cursor_line=False,
                         placeholder="Enter text to upload...",
                     )
-                    if self._external_editor:
+                    if external_editor():
                         yield Label("[$accent]\\[f3][/] for $EDITOR", id="editor-help")
                 with TabPane("File [$accent]\\[^f][/]", id="file"):
                     yield Button("Select file...", id="select-file")
@@ -249,23 +235,8 @@ class UserUpload(ModalScreen[UploadData | None]):
 
     def action_edit_externally(self) -> None:
         """Edit the input in an external editor."""
-        if not (
-            (editor := self._external_editor) and self._text_or_file.active == "text"
-        ):
-            return
-        with NamedTemporaryFile(
-            mode="w+", delete=False, encoding="utf-8", suffix=DEFAULT_GEMINI_EXTENSION
-        ) as temp_file:
-            user_input = Path(temp_file.name)
-            temp_file.write(self._text.text)
-            temp_file.close()
-            try:
-                with self.app.suspend():
-                    run((editor, user_input))
-                self._text.text = user_input.read_text(encoding="utf-8")
-                self._text.focus()
-            finally:
-                user_input.unlink(missing_ok=True)
+        if self._text_or_file.active == "text":
+            self._text.text = edit_externally(self.app, self._text.text)
 
 
 ### user_upload.py ends here

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -161,7 +161,6 @@ class UserUpload(ModalScreen[UploadData | None]):
         """Compose the screen."""
         with VerticalGroup() as dialog:
             dialog.border_title = f"Upload to {self._location}"
-            dialog.border_subtitle = "Titan"
             with TabbedContent():
                 with TabPane("Text [$accent]\\[^t][/]", id="text"):
                     yield TextArea(

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -192,13 +192,15 @@ class UserUpload(ModalScreen[UploadData | None]):
 
     def action_prepare_file(self) -> None:
         """Switch to the file tab."""
-        self.screen.focused = self._text_or_file
         self._text_or_file.active = "file"
+        self.query_one("Tabs").focus()
+        self.call_after_refresh(self.focus_next)
 
     def action_prepare_text(self) -> None:
         """Switch to the text tab."""
-        self.screen.focused = self._text_or_file
         self._text_or_file.active = "text"
+        self.query_one("Tabs").focus()
+        self.call_after_refresh(self.focus_next)
 
     @on(TextArea.Changed)
     def _text_changed(self) -> None:

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -189,7 +189,7 @@ class UserUpload(ModalScreen[UploadData | None]):
                 yield Label("Token:", classes="--title")
                 yield Input(placeholder="Enter token (optional)", id="token")
             with HorizontalGroup(id="buttons"):
-                yield Button(add_key("Upload", "F2", self), id="upload")
+                yield Button(add_key("Upload", "f2", self), id="upload")
                 yield Button(add_key("Cancel", "Esc", self), id="cancel")
 
     def action_prepare_file(self) -> None:

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -192,6 +192,12 @@ class UserUpload(ModalScreen[UploadData | None]):
                 yield Button(add_key("Upload", "f2", self), id="upload")
                 yield Button(add_key("Cancel", "Esc", self), id="cancel")
 
+    def on_mount(self) -> None:
+        """Focus the text area on mount."""
+        self._refresh_character_count()
+        if self._existing_content:
+            self._text.focus()
+
     def action_prepare_file(self) -> None:
         """Switch to the file tab."""
         self._text_or_file.active = "file"
@@ -205,7 +211,7 @@ class UserUpload(ModalScreen[UploadData | None]):
         self.call_after_refresh(self.focus_next)
 
     @on(TextArea.Changed)
-    def _text_changed(self) -> None:
+    def _refresh_character_count(self) -> None:
         """Update the text size count."""
         self._character_count.update(
             f"Characters: {len(self._text.text)}" if self._text.text else ""

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -99,8 +99,14 @@ class UserUpload(ModalScreen[UploadData | None]):
                 }
             }
 
+            #character-count {
+                width: 1fr;
+                padding-left: 1;
+                color: $text-muted;
+            }
+
             #editor-help {
-                width: 100%;
+                width: 1fr;
                 content-align: right middle;
                 padding-right: 1;
             }
@@ -124,6 +130,8 @@ class UserUpload(ModalScreen[UploadData | None]):
         ("escape", "cancel"),
     ]
 
+    _character_count = query_one("#character-count", Label)
+    """The label displaying the character count."""
     _text_or_file = query_one(TabbedContent)
     """The tabbed content widget for text or file."""
     _selected_file_display = query_one("#selected-file", Label)
@@ -158,8 +166,13 @@ class UserUpload(ModalScreen[UploadData | None]):
                         highlight_cursor_line=False,
                         placeholder="Enter text to upload...",
                     )
-                    if external_editor():
-                        yield Label("[$accent]\\[f3][/] for $EDITOR", id="editor-help")
+                    with HorizontalGroup():
+                        yield Label(id="character-count")
+                        if external_editor():
+                            yield Label(
+                                "[dim][$accent]\\[f3][/] for $EDITOR[/]",
+                                id="editor-help",
+                            )
                 with TabPane("File [$accent]\\[^f][/]", id="file"):
                     yield Button("Select file...", id="select-file")
                     yield Label("Selected file:", classes="--title")
@@ -186,6 +199,13 @@ class UserUpload(ModalScreen[UploadData | None]):
         """Switch to the text tab."""
         self.screen.focused = self._text_or_file
         self._text_or_file.active = "text"
+
+    @on(TextArea.Changed)
+    def _text_changed(self) -> None:
+        """Update the text size count."""
+        self._character_count.update(
+            f"Characters: {len(self._text.text)}" if self._text.text else ""
+        )
 
     @on(Button.Pressed, "#select-file")
     async def _select_file(self) -> None:

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -143,7 +143,7 @@ class UserUpload(ModalScreen[UploadData | None]):
     _token = query_one("#token", Input)
     """The token input."""
 
-    def __init__(self, location: TitanURI) -> None:
+    def __init__(self, location: TitanURI, existing_content: str) -> None:
         """Initialise the screen.
 
         Args:
@@ -152,6 +152,8 @@ class UserUpload(ModalScreen[UploadData | None]):
         super().__init__()
         self._location = location
         """The location to upload to."""
+        self._existing_content = existing_content
+        """The existing content at the location."""
         self._selected_file: Path | None = None
         """The selected file to upload."""
 
@@ -163,6 +165,7 @@ class UserUpload(ModalScreen[UploadData | None]):
             with TabbedContent():
                 with TabPane("Text [$accent]\\[^t][/]", id="text"):
                     yield TextArea(
+                        self._existing_content,
                         highlight_cursor_line=False,
                         placeholder="Enter text to upload...",
                     )

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -141,12 +141,12 @@ class UserUpload(ModalScreen[UploadData | None]):
             dialog.border_title = f"Upload to {self._location}"
             dialog.border_subtitle = "Titan"
             with TabbedContent():
-                with TabPane("Text [$accent]\\[F3][/]", id="text"):
+                with TabPane("Text [$accent]\\[f3][/]", id="text"):
                     yield TextArea(
                         highlight_cursor_line=False,
                         placeholder="Enter text to upload...",
                     )
-                with TabPane("File [$accent]\\[F4][/]", id="file"):
+                with TabPane("File [$accent]\\[f4][/]", id="file"):
                     yield Button("Select file...", id="select-file")
                     yield Label("Selected file:", classes="--gap-above --title")
                     yield Label("<none>", id="selected-file", classes="--empty")

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -97,6 +97,7 @@ class UserUpload(ModalScreen[UploadData | None]):
             .--gap-above {
                 margin-top: 1;
             }
+
             .--title {
                 color: $accent;
             }

--- a/src/rogallo/screens/user_upload.py
+++ b/src/rogallo/screens/user_upload.py
@@ -95,6 +95,12 @@ class UserUpload(ModalScreen[UploadData | None]):
                 }
             }
 
+            #editor-help {
+                width: 100%;
+                content-align: right middle;
+                padding-right: 1;
+            }
+
             .--empty {
                 color: $text-muted;
             }
@@ -163,7 +169,7 @@ class UserUpload(ModalScreen[UploadData | None]):
                         placeholder="Enter text to upload...",
                     )
                     if self._external_editor:
-                        yield Label("[$accent]\\[f3][/] for $EDITOR")
+                        yield Label("[$accent]\\[f3][/] for $EDITOR", id="editor-help")
                 with TabPane("File [$accent]\\[^f][/]", id="file"):
                     yield Button("Select file...", id="select-file")
                     yield Label("Selected file:", classes="--gap-above --title")

--- a/src/rogallo/types.py
+++ b/src/rogallo/types.py
@@ -23,10 +23,12 @@ from sybaritic import SpartanURI
 
 ##############################################################################
 # Wasat imports.
-from wasat import GeminiURI
+from wasat import GeminiURI, TitanURI
 
 ##############################################################################
-type RogalloLocation = Path | GeminiURI | FingerURI | GopherURI | SpartanURI | NexURI
+type RogalloLocation = (
+    Path | GeminiURI | TitanURI | FingerURI | GopherURI | SpartanURI | NexURI
+)
 """The type of a location handled by Rogallo."""
 
 ##############################################################################
@@ -38,6 +40,7 @@ SUPPORTED_PROTOCOLS: Final[frozenset[str]] = frozenset(
         "gopher",
         "nex",
         "spartan",
+        "titan",
     }
 )
 """The set of protocols handled by Rogallo."""

--- a/src/rogallo/widgets/viewer/gemtext/link.py
+++ b/src/rogallo/widgets/viewer/gemtext/link.py
@@ -43,6 +43,7 @@ from ....preflight import (
     is_local_gemtext_file,
     is_nex_uri,
     is_spartan_uri,
+    is_titan_uri,
 )
 from ....safe_escape import escape
 from ....types import RogalloLocation, SpartanURINeedingData
@@ -143,12 +144,13 @@ class GemtextLink(Widget, can_focus=True):
     def _best_icon(self) -> str:
         """Get the best icon for the link based on its URI."""
         for checker, icon_name in (
-            (is_likely_capsule, "geminispace_link_icon"),
             (is_finger_uri, "fingerspace_link_icon"),
             (is_gopher_uri, "gopherspace_link_icon"),
-            (is_spartan_uri, "spartanspace_link_icon"),
-            (is_nex_uri, "nexspace_link_icon"),
+            (is_likely_capsule, "geminispace_link_icon"),
             (is_local_gemtext_file, "geminispace_link_icon"),
+            (is_nex_uri, "nexspace_link_icon"),
+            (is_spartan_uri, "spartanspace_link_icon"),
+            (is_titan_uri, "titanspace_link_icon"),
         ):
             if checker(self.normalised_uri):
                 return icon(icon_name)

--- a/uv.lock
+++ b/uv.lock
@@ -1885,7 +1885,7 @@ requires-dist = [
     { name = "textual-fspicker", specifier = ">=1.0.1" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=1.9.0" },
+    { name = "wasat", specifier = ">=1.9.1" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -2088,14 +2088,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "1.9.0"
+version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/1b/624c01a86ec3f0157d8206b931b5194353ed7226a7cdf92907d49d78b294/wasat-1.9.0.tar.gz", hash = "sha256:52e76f49c0248c31e4ab32c1592f1de88c69c6e3a3c90e42b8c6faf195bbe960", size = 39353, upload-time = "2026-09-05T07:20:23.494Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/ae/54991304bc0fc0578e1cbceed4d35c1e9174e25b79ecdb3dfd3d314ef9ed/wasat-1.9.1.tar.gz", hash = "sha256:26d7d643e93398f865fa25e064ed486d31f90ced838b2e3855a18b44ca10aa37", size = 40201, upload-time = "2026-09-05T10:06:24.35Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/18/f1de81130a4d745bb416c1b1ab446c20cafea0e6e637b2f14a4e9f9dfb5a/wasat-1.9.0-py3-none-any.whl", hash = "sha256:b8d61335b7ce69ff2a7da1d747a49366d4caf53895aa99e570dc908ee6e9a9ca", size = 43248, upload-time = "2026-09-05T07:20:22.237Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c8/02759404a0fe86db2b158810d654d10a560b4eaccc67e512c84b653b2842/wasat-1.9.1-py3-none-any.whl", hash = "sha256:8b76b37cdbf16412dd0d2d8b85a8d98ceb70f38f0a5e6b7d98c269ac79e50a55", size = 44062, upload-time = "2026-09-05T10:06:23.052Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1885,7 +1885,7 @@ requires-dist = [
     { name = "textual-fspicker", specifier = ">=1.0.1" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=1.8.1" },
+    { name = "wasat", specifier = ">=1.9.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -2088,14 +2088,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "1.8.1"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/89/b274d1dc503060822d9805e172a227c81d3d22e25b0cac9780a84131d879/wasat-1.8.1.tar.gz", hash = "sha256:4cfbffc1a6dfd1c4cc1a67170b74d99e7387916f8e68551be6bf22c6bfa1adf8", size = 38677, upload-time = "2026-09-04T19:54:48.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/1b/624c01a86ec3f0157d8206b931b5194353ed7226a7cdf92907d49d78b294/wasat-1.9.0.tar.gz", hash = "sha256:52e76f49c0248c31e4ab32c1592f1de88c69c6e3a3c90e42b8c6faf195bbe960", size = 39353, upload-time = "2026-09-05T07:20:23.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/fb/99977aaf3c01ce7b4a71be1f80e3e5ff97e91c97c5f687d1066a03294b92/wasat-1.8.1-py3-none-any.whl", hash = "sha256:57f637c003118b858a59f56e1eea21dc9ad497c589c2b74a9dd7907455978199", size = 42566, upload-time = "2026-09-04T19:54:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/18/f1de81130a4d745bb416c1b1ab446c20cafea0e6e637b2f14a4e9f9dfb5a/wasat-1.9.0-py3-none-any.whl", hash = "sha256:b8d61335b7ce69ff2a7da1d747a49366d4caf53895aa99e570dc908ee6e9a9ca", size = 43248, upload-time = "2026-09-05T07:20:22.237Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1885,7 +1885,7 @@ requires-dist = [
     { name = "textual-fspicker", specifier = ">=1.0.1" },
     { name = "types-pygments", specifier = ">=2.20.0.20260518" },
     { name = "types-pyperclip", specifier = ">=1.11.0.20260508" },
-    { name = "wasat", specifier = ">=1.8.0" },
+    { name = "wasat", specifier = ">=1.8.1" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -2088,14 +2088,14 @@ wheels = [
 
 [[package]]
 name = "wasat"
-version = "1.8.0"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/75/136de1d5ed27df9126f020fe8c55b033cefa4ab27b4aed1eaae620c6de04/wasat-1.8.0.tar.gz", hash = "sha256:330f523965bb9f956f7d645069f331e2ebef6dc5f8c837f85b1ba24651759396", size = 38050, upload-time = "2026-09-03T17:53:51.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/89/b274d1dc503060822d9805e172a227c81d3d22e25b0cac9780a84131d879/wasat-1.8.1.tar.gz", hash = "sha256:4cfbffc1a6dfd1c4cc1a67170b74d99e7387916f8e68551be6bf22c6bfa1adf8", size = 38677, upload-time = "2026-09-04T19:54:48.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/a5/b608a43ae0f1f8444c7086b8e34ad937b52679004d5446f38ea8ecca576f/wasat-1.8.0-py3-none-any.whl", hash = "sha256:986c931a2ae226e85fcbf61d4b8bb211faec21e28a602c769c31bfb2351ce71b", size = 41917, upload-time = "2026-09-03T17:53:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fb/99977aaf3c01ce7b4a71be1f80e3e5ff97e91c97c5f687d1066a03294b92/wasat-1.8.1-py3-none-any.whl", hash = "sha256:57f637c003118b858a59f56e1eea21dc9ad497c589c2b74a9dd7907455978199", size = 42566, upload-time = "2026-09-04T19:54:46.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds support for uploading data using Titan. Also adds support for the `;edit` extension to Titan.

<img width="971" height="976" alt="Screenshot 2026-09-05 at 09 41 34" src="https://github.com/user-attachments/assets/8dead7fa-4baf-42d5-a437-310be97d8cd4" />

<img width="920" height="960" alt="Screenshot 2026-09-04 at 15 44 41" src="https://github.com/user-attachments/assets/c0179ea7-f3fa-435c-a1f8-3425fe93b734" />

TODO:

- [x] Add a "rich input/upload" dialog, that's like the user input interface but allows for attached files, setting the mime type, etc.
    - [x] Allow calling out to $EDITOR to enter the free text
- [x] Add the actual handler code.
- [x] Confirm if a response to a Titan upload can be a 6x
- [x] Add support for the `;edit` extension to Titan
- [x] Add a protocol page in the documentation.
- [x] Update protocol lists in the README, docs, GitHub page, etc, to include Titan.
- [x] Attempting to upload a file bigger than BBS allows (as a test) causes Rogallo to freeze and never come back. Investigate and fix.
- [x] Enable content saving on error (similar to how Gemini user inputs work).

Closes #355.