### PR TITLE
Move aliases to their own dedicated file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@
 - Added support for loading keyboard bindings from a separate file
   (`bindings.yaml`) in the configuration directory.
   ([#436](https://github.com/davep/rogallo/pull/436))
+- **BREAKING CHANGE:** Command line aliases are now loaded from
+  `aliases.yaml` rather than `configuration.json`.
+  ([#438](https://github.com/davep/rogallo/pull/438))
 
 ## v2.4.0
 

--- a/docs/source/ui/command-line.md
+++ b/docs/source/ui/command-line.md
@@ -53,16 +53,17 @@ for help_line in sorted(chain(*(command.help_text() for command in COMMANDS))):
 
 Rogallo supports a simple form of aliases for its command line. Primarily
 they're useful for defining things such as performing searches using popular
-Gemini and Gopher search engines. Aliases are defined in the [configuration
-file](../configuration/index.md), like this:
+Gemini and Gopher search engines. Aliases are defined in a file called
+`aliases.yaml`, which is placed in the [configuration
+directory](../configuration/directory.md).
 
-```json
-"aliases": {
-    "fg": "gopher://gopher.floodgap.com/1/v2/vs?{q}",
-    "gp": "gemini://gemi.dev/cgi-bin/wp.cgi/search?{q}",
-    "ken": "gemini://kennedy.gemi.dev/search?{q}",
-    "tlgs": "gemini://tlgs.one/search?{q}"
-}
+The default version of the file looks like this:
+
+```yaml
+fg: gopher://gopher.floodgap.com/1/v2/vs?{q}
+gp: gemini://gemi.dev/cgi-bin/wp.cgi/search?{q}
+ken: gemini://kennedy.gemi.dev/search?{q}
+tlgs: gemini://tlgs.one/search?{q}
 ```
 
 Aliases can include template variables (`{q}`, `{qp}`, `{r}`) that are
@@ -92,9 +93,15 @@ searches with search engines, this isn't the only application. For example,
 if you preferred to type `whois` rather than `!finger` to call on a finger
 server, you could have:
 
-```json
-"whois": "!finger {r}"
+```yaml
+whois: "!finger {r}"
 ```
+
+!!! tip
+
+    The aliases file is a [YAML](https://yaml.org/) file. If you set up an alias and it doesn't
+    seem to work in the way you hoped, try wrapping the right-hand side in
+    quotes, as you can see in the `whois` example above.
 
 ## History and completion
 

--- a/src/rogallo/__main__.py
+++ b/src/rogallo/__main__.py
@@ -9,6 +9,7 @@ from operator import attrgetter
 ##############################################################################
 # Local imports.
 from . import __doc__, __version__
+from .data import initial_load
 from .data.locations import cache_dir, config_dir, data_dir
 from .rogallo import Rogallo
 
@@ -217,6 +218,7 @@ def main() -> None:
         case "themes":
             show_themes()
         case _:
+            initial_load()
             Rogallo(args).run()
 
 

--- a/src/rogallo/data/__init__.py
+++ b/src/rogallo/data/__init__.py
@@ -2,6 +2,7 @@
 
 ##############################################################################
 # Local imports.
+from .aliases import load_aliases
 from .bindings import load_bindings
 from .bookmarks import Bookmark, Bookmarks, load_bookmarks, save_bookmarks
 from .client_certificates import client_certificates_directory
@@ -16,6 +17,7 @@ from .config import (
     save_configuration,
     update_configuration,
 )
+from .initial_load import initial_load
 from .location_history import (
     LocationHistory,
     LocationVisit,
@@ -41,10 +43,12 @@ __all__ = [
     "client_certificates_directory",
     "CommandLineHistory",
     "Configuration",
+    "load_aliases",
     "load_bindings",
     "load_bookmarks",
     "load_command_history",
     "load_configuration",
+    "initial_load",
     "load_location_history",
     "load_navigation_history",
     "load_themes",

--- a/src/rogallo/data/aliases.py
+++ b/src/rogallo/data/aliases.py
@@ -1,0 +1,57 @@
+"""Provides code for loading the command line aliases."""
+
+##############################################################################
+# Python imports.
+from functools import cache
+from pathlib import Path
+from typing import Final
+
+##############################################################################
+# PyYAML imports.
+from yaml import YAMLError, safe_dump, safe_load
+
+##############################################################################
+# Local imports.
+from .locations import config_dir
+
+##############################################################################
+type Aliases = dict[str, str]
+"""Type for aliases."""
+
+##############################################################################
+_DEFAULT_ALIASES: Final[Aliases] = {
+    "fg": "gopher://gopher.floodgap.com/1/v2/vs?{q}",
+    "gp": "gemini://gemi.dev/cgi-bin/wp.cgi/search?{q}",
+    "ken": "gemini://kennedy.gemi.dev/search?{q}",
+    "tlgs": "gemini://tlgs.one/search?{q}",
+}
+"""The default aliases."""
+
+
+##############################################################################
+def aliases_file() -> Path:
+    """The path to the file that holds the aliases.
+
+    Returns:
+        The path to the aliases file.
+    """
+    return config_dir() / "aliases.yaml"
+
+
+##############################################################################
+@cache
+def load_aliases() -> Aliases:
+    """Load the aliases.
+
+    Returns:
+        The loaded aliases.
+    """
+    if not aliases_file().exists():
+        aliases_file().write_text(safe_dump(_DEFAULT_ALIASES), encoding="utf-8")
+    try:
+        return safe_load(aliases_file().read_text(encoding="utf-8")) or {}
+    except (OSError, YAMLError):
+        return {}
+
+
+### aliases.py ends here

--- a/src/rogallo/data/config.py
+++ b/src/rogallo/data/config.py
@@ -175,16 +175,6 @@ class Configuration:
     )
     """The badges to use for Gopher item types."""
 
-    aliases: dict[str, str] = field(
-        default_factory=lambda: {
-            "fg": "gopher://gopher.floodgap.com/1/v2/vs?{q}",
-            "gp": "gemini://gemi.dev/cgi-bin/wp.cgi/search?{q}",
-            "ken": "gemini://kennedy.gemi.dev/search?{q}",
-            "tlgs": "gemini://tlgs.one/search?{q}",
-        }
-    )
-    """Aliases to use in the command line."""
-
     guess_language_for_syntax_highlighting_text_documents: bool = True
     """Whether to guess the language for syntax highlighting of text documents."""
 

--- a/src/rogallo/data/initial_load.py
+++ b/src/rogallo/data/initial_load.py
@@ -1,0 +1,22 @@
+"""Provides a function to initially load some data.
+
+Most configuration data is cached, so any part of the application can call
+on the load function without needing to worry about keeping its own cache.
+However, it's useful for the user that, after first run, any defaults that
+should be written to file get written right away, rather than on first-need.
+
+This module provides a function to do that initial load/create.
+"""
+
+##############################################################################
+# Local imports.
+from .aliases import load_aliases
+
+
+##############################################################################
+def initial_load() -> None:
+    """Perform an initial load of some application data."""
+    load_aliases()
+
+
+### initial_load.py ends here

--- a/src/rogallo/widgets/command_line/aliases.py
+++ b/src/rogallo/widgets/command_line/aliases.py
@@ -7,7 +7,7 @@ from urllib.parse import quote, quote_plus
 
 ##############################################################################
 # Local imports.
-from ...data import load_configuration
+from ...data import load_aliases
 
 
 ##############################################################################
@@ -25,7 +25,7 @@ def expand_aliases(command_line: str) -> str:
     Returns:
         The expanded command line.
     """
-    aliases = load_configuration().aliases
+    aliases = load_aliases()
     car, _, cdr = command_line.partition(" ")
     if car in aliases:
         cdr = cdr.strip()

--- a/src/rogallo/widgets/command_line/widget.py
+++ b/src/rogallo/widgets/command_line/widget.py
@@ -41,6 +41,7 @@ from ...data import (
     CommandLineHistory,
     LocationHistory,
     NavigationHistory,
+    load_aliases,
     load_configuration,
 )
 from ...presentation import short_location
@@ -137,9 +138,9 @@ class CommandLine(Vertical):
         aliases="\n    ".join(
             sorted(
                 f"| {alias} | {expansion} |"
-                for alias, expansion in load_configuration().aliases.items()
+                for alias, expansion in load_aliases().items()
             )
-            if load_configuration().aliases
+            if load_aliases()
             else ["| (none) | (none) |"]
         ),
     )


### PR DESCRIPTION
Rather than define aliases in `configuration.json`, they are now looked for and loaded from `aliases.yaml`.

This is another step in handling #343.