### PR TITLE
Rearrange where most of the config code lives

### DIFF
--- a/src/rogallo/data/__init__.py
+++ b/src/rogallo/data/__init__.py
@@ -2,8 +2,6 @@
 
 ##############################################################################
 # Local imports.
-from .aliases import load_aliases
-from .bindings import load_bindings
 from .bookmarks import Bookmark, Bookmarks, load_bookmarks, save_bookmarks
 from .client_certificates import client_certificates_directory
 from .command_history import (
@@ -16,6 +14,12 @@ from .config import (
     load_configuration,
     save_configuration,
     update_configuration,
+)
+from .configuration import (
+    load_aliases,
+    load_bindings,
+    load_themes,
+    load_toolbar,
 )
 from .initial_load import initial_load
 from .location_history import (
@@ -30,8 +34,6 @@ from .navigation_history import (
     load_navigation_history,
     save_naviagation_history,
 )
-from .themes import load_themes
-from .toolbar import load_toolbar
 from .trust import trust_file
 from .trusted_mime_types import load_trusted_mime_types, save_trusted_mime_types
 from .trusted_schemes import load_trusted_schemes, save_trusted_schemes

--- a/src/rogallo/data/__init__.py
+++ b/src/rogallo/data/__init__.py
@@ -9,17 +9,15 @@ from .command_history import (
     load_command_history,
     save_command_history,
 )
-from .config import (
-    Configuration,
-    load_configuration,
-    save_configuration,
-    update_configuration,
-)
 from .configuration import (
+    Configuration,
     load_aliases,
     load_bindings,
+    load_configuration,
     load_themes,
     load_toolbar,
+    save_configuration,
+    update_configuration,
 )
 from .initial_load import initial_load
 from .location_history import (

--- a/src/rogallo/data/configuration/__init__.py
+++ b/src/rogallo/data/configuration/__init__.py
@@ -8,17 +8,27 @@ will live in XDG_CONFIG_HOME.
 # Local imports.
 from .aliases import load_aliases
 from .bindings import load_bindings
+from .general import (
+    Configuration,
+    load_configuration,
+    save_configuration,
+    update_configuration,
+)
 from .themes import load_themes
 from .toolbar import ToolbarConfiguration, load_toolbar
 
 ##############################################################################
 # Exports.
 __all__ = [
+    "Configuration",
     "load_aliases",
     "load_bindings",
+    "load_configuration",
     "load_themes",
     "load_toolbar",
+    "save_configuration",
     "ToolbarConfiguration",
+    "update_configuration",
 ]
 
 ### __init__.py ends here

--- a/src/rogallo/data/configuration/__init__.py
+++ b/src/rogallo/data/configuration/__init__.py
@@ -1,0 +1,24 @@
+"""Provides code for managing the application's configuration data.
+
+The data in this module is intended to be all the user-supplied values that
+will live in XDG_CONFIG_HOME.
+"""
+
+##############################################################################
+# Local imports.
+from .aliases import load_aliases
+from .bindings import load_bindings
+from .themes import load_themes
+from .toolbar import ToolbarConfiguration, load_toolbar
+
+##############################################################################
+# Exports.
+__all__ = [
+    "load_aliases",
+    "load_bindings",
+    "load_themes",
+    "load_toolbar",
+    "ToolbarConfiguration",
+]
+
+### __init__.py ends here

--- a/src/rogallo/data/configuration/aliases.py
+++ b/src/rogallo/data/configuration/aliases.py
@@ -12,7 +12,7 @@ from yaml import YAMLError, safe_dump, safe_load
 
 ##############################################################################
 # Local imports.
-from .locations import config_dir
+from ..locations import config_dir
 
 ##############################################################################
 type Aliases = dict[str, str]

--- a/src/rogallo/data/configuration/bindings.py
+++ b/src/rogallo/data/configuration/bindings.py
@@ -14,7 +14,7 @@ from yaml import YAMLError, safe_load
 
 ##############################################################################
 # Local imports.
-from .locations import config_dir
+from ..locations import config_dir
 
 
 ##############################################################################

--- a/src/rogallo/data/configuration/general.py
+++ b/src/rogallo/data/configuration/general.py
@@ -16,7 +16,7 @@ from gophermap import ItemType
 
 ##############################################################################
 # Local imports.
-from .locations import config_dir
+from ..locations import config_dir
 
 
 ##############################################################################

--- a/src/rogallo/data/configuration/themes.py
+++ b/src/rogallo/data/configuration/themes.py
@@ -14,7 +14,7 @@ from textual.theme import Theme
 
 ##############################################################################
 # Local imports.
-from .locations import config_dir
+from ..locations import config_dir
 
 
 ##############################################################################

--- a/src/rogallo/data/configuration/toolbar.py
+++ b/src/rogallo/data/configuration/toolbar.py
@@ -17,7 +17,7 @@ from yaml import YAMLError, safe_dump, safe_load
 
 ##############################################################################
 # Local imports.
-from .locations import config_dir
+from ..locations import config_dir
 
 
 ##############################################################################

--- a/src/rogallo/data/initial_load.py
+++ b/src/rogallo/data/initial_load.py
@@ -10,8 +10,8 @@ This module provides a function to do that initial load/create.
 
 ##############################################################################
 # Local imports.
-from .aliases import load_aliases
-from .toolbar import load_toolbar
+from .configuration.aliases import load_aliases
+from .configuration.toolbar import load_toolbar
 
 
 ##############################################################################

--- a/src/rogallo/data/initial_load.py
+++ b/src/rogallo/data/initial_load.py
@@ -10,8 +10,7 @@ This module provides a function to do that initial load/create.
 
 ##############################################################################
 # Local imports.
-from .configuration.aliases import load_aliases
-from .configuration.toolbar import load_toolbar
+from .configuration import load_aliases, load_toolbar
 
 
 ##############################################################################

--- a/src/rogallo/widgets/toolbar.py
+++ b/src/rogallo/widgets/toolbar.py
@@ -22,7 +22,7 @@ from textual_enhanced.commands.bindings import primary_key_for
 
 ##############################################################################
 # Local imports.
-from ..data.toolbar import ToolbarConfiguration
+from ..data.configuration import ToolbarConfiguration
 
 
 ##############################################################################


### PR DESCRIPTION
The main `data` module is getting a wee bit crowded, and so I'd like to split it up a little more. Generally the aim is to split it up by where, from an XDG perspective, the data will end up being held. This PR concentrates on data that will go into `XDG_CONFIG_HOME`.